### PR TITLE
Faster bulk inserts

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -443,6 +443,7 @@ func (txn *Txn) deletePending() {
 	// Clear the items in the collection and reinitialize the purge list
 	txn.owner.lock.Lock()
 	txn.owner.fill.AndNot(txn.deletes)
+	txn.owner.count = txn.owner.fill.Count()
 
 	// If there's an associated writer, write into it
 	if txn.writer != nil {
@@ -466,6 +467,7 @@ func (txn *Txn) insertPending() {
 
 	txn.owner.lock.Lock()
 	txn.owner.fill.Or(txn.inserts)
+	txn.owner.count = txn.owner.fill.Count()
 
 	// If there's a writer, write before we unlock the column so that the transactions
 	// are seiralized in the writer as well, making everything consistent.


### PR DESCRIPTION
This speeds up the bulk inserts by checking the last page first before scanning from the beginning to find an index in order to perform the insertion. In the (most likely) case that there's space at the tail, we add the item there. Note that we'd still perform the full scan if the last page is slow, this case will need to be optimized.