### PR TITLE
Faster filtering

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -20,15 +20,16 @@ import (
 )
 
 /*
-BenchmarkCollection/insert-8         	 5545016	       216.8 ns/op	      18 B/op	       0 allocs/op
-BenchmarkCollection/fetch-8          	27272726	        43.61 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/scan-8           	     648	   1844623 ns/op	     147 B/op	       0 allocs/op
-BenchmarkCollection/count-8          	 1000000	      1107 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/range-8          	   10000	    102549 ns/op	       9 B/op	       0 allocs/op
-BenchmarkCollection/update-at-8      	 4316584	       280.7 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/update-all-8     	     826	   1379693 ns/op	   53068 B/op	       0 allocs/op
-BenchmarkCollection/delete-at-8      	 7059126	       169.1 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/delete-all-8     	  196734	      6294 ns/op	       0 B/op	       0 allocs/op
+cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
+BenchmarkCollection/insert-8         	 5531546	       215.9 ns/op	      18 B/op	       0 allocs/op
+BenchmarkCollection/fetch-8          	23749724	        44.97 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/scan-8           	     784	   1527506 ns/op	     160 B/op	       0 allocs/op
+BenchmarkCollection/count-8          	 1000000	      1081 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/range-8          	   10000	    100833 ns/op	      14 B/op	       0 allocs/op
+BenchmarkCollection/update-at-8      	 4225484	       281.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/update-all-8     	     830	   1388480 ns/op	  105714 B/op	       0 allocs/op
+BenchmarkCollection/delete-at-8      	 6928646	       171.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/delete-all-8     	  180884	      6373 ns/op	       1 B/op	       0 allocs/op
 */
 func BenchmarkCollection(b *testing.B) {
 	amount := 100000
@@ -156,7 +157,7 @@ func BenchmarkCollection(b *testing.B) {
 // Test replication many times
 func TestReplicate(t *testing.T) {
 	for x := 0; x < 20; x++ {
-		runReplication(t, 5000, 500)
+		runReplication(t, 5000, 50)
 	}
 }
 

--- a/column_generate.go
+++ b/column_generate.go
@@ -117,30 +117,24 @@ func (c *columnnumber) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnnumber) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnnumber) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnnumber) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -36,7 +36,7 @@ func (c *columnFloat32) Grow(idx uint32) {
 		return
 	}
 
-	//	c.fill.Grow(idx)
+	c.fill.Grow(idx)
 	clone := make([]float32, idx+1, capacityFor(idx+1))
 	copy(clone, c.data)
 	c.data = clone
@@ -116,31 +116,25 @@ func (c *columnFloat32) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnFloat32) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnFloat32) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnFloat32) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -251,31 +245,25 @@ func (c *columnFloat64) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnFloat64) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnFloat64) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnFloat64) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -386,31 +374,25 @@ func (c *columnInt) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnInt) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnInt) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnInt) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -521,31 +503,25 @@ func (c *columnInt16) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnInt16) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnInt16) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnInt16) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -656,31 +632,25 @@ func (c *columnInt32) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnInt32) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnInt32) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnInt32) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -791,31 +761,25 @@ func (c *columnInt64) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnInt64) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnInt64) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnInt64) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -926,31 +890,25 @@ func (c *columnUint) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnUint) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnUint) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnUint) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -1061,31 +1019,25 @@ func (c *columnUint16) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnUint16) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnUint16) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnUint16) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -1196,31 +1148,25 @@ func (c *columnUint32) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnUint32) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnUint32) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnUint32) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }
 
@@ -1331,30 +1277,24 @@ func (c *columnUint64) LoadUint64(idx uint32) (v uint64, ok bool) {
 
 // FilterFloat64 filters down the values based on the specified predicate.
 func (c *columnUint64) FilterFloat64(index *bitmap.Bitmap, predicate func(v float64) bool) {
-	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(float64(c.data[idx]))
-		}
-		return
+	index.And(c.fill)
+	index.Filter(func(idx uint32) bool {
+		return idx < uint32(len(c.data)) && predicate(float64(c.data[idx]))
 	})
 }
 
 // FilterInt64 filters down the values based on the specified predicate.
 func (c *columnUint64) FilterInt64(index *bitmap.Bitmap, predicate func(v int64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(int64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(int64(c.data[idx]))
 	})
 }
 
 // FilterUint64 filters down the values based on the specified predicate.
 func (c *columnUint64) FilterUint64(index *bitmap.Bitmap, predicate func(v uint64) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
-			match = predicate(uint64(c.data[idx]))
-		}
-		return
+		return idx < uint32(len(c.data)) && predicate(uint64(c.data[idx]))
 	})
 }

--- a/examples/million/main.go
+++ b/examples/million/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	amount, runs := 20000000, 50
+	amount, runs := 1000000, 50
 	players := column.NewCollection(column.Options{
 		Capacity: amount,
 	})


### PR DESCRIPTION
This PR speeds up filtering by around `10-15%` by avoiding calling to `Contains` on each item in the `fill` list. Instead, we do a SIMD-accelerated `AND` right before the filter loop, cutting out all of the elements that are not present out of the index. The benchmarks are conservative, and this `AND` operation doesn't actually eliminate anything since all of the rows have the column. 

Not only it removes the `Contains` calls but also in the case of numbers it *should* reduce branch mispredictions as there's no more branches during the filter,  but I haven't checked the numbers.