### PR TITLE
Refactor commit & speed up insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ When testing for larger collections, I added a small example (see `examples` fol
 
 ```
 running insert of 20000000 rows...
--> insert took 38.6921853s
+-> insert took 22.7740005s
 
 running full scan of age >= 30...
 -> result = 10200000

--- a/collection_test.go
+++ b/collection_test.go
@@ -204,6 +204,8 @@ func runReplication(t *testing.T, updates, inserts int) {
 		for i := 0; i < updates; i++ {
 			go func() {
 				defer wg.Done()
+
+				// Randomly update a column
 				offset := uint32(rand.Int31n(int32(inserts - 1)))
 				switch rand.Int31n(3) {
 				case 0:
@@ -212,6 +214,16 @@ func runReplication(t *testing.T, updates, inserts int) {
 					primary.UpdateAt(offset, "int32", rand.Int31n(100000))
 				case 2:
 					primary.UpdateAt(offset, "string", fmt.Sprintf("hi %v", rand.Int31n(100)))
+				}
+
+				// Randomly delete an item
+				if rand.Int31n(100) == 0 {
+					primary.DeleteAt(uint32(rand.Int31n(int32(inserts - 1))))
+				}
+
+				// Randomly insert an item
+				if rand.Int31n(100) == 0 {
+					primary.Insert(object)
 				}
 			}()
 		}

--- a/column.go
+++ b/column.go
@@ -273,8 +273,9 @@ func (c *columnAny) LoadString(idx uint32) (string, bool) {
 // FilterString filters down the values based on the specified predicate. The column for
 // this filter must be a string.
 func (c *columnAny) FilterString(index *bitmap.Bitmap, predicate func(v string) bool) {
+	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) && c.fill.Contains(idx) {
+		if idx < uint32(len(c.data)) {
 			if s, ok := c.LoadString(idx); ok {
 				return predicate(s)
 			}

--- a/column.go
+++ b/column.go
@@ -275,12 +275,7 @@ func (c *columnAny) LoadString(idx uint32) (string, bool) {
 func (c *columnAny) FilterString(index *bitmap.Bitmap, predicate func(v string) bool) {
 	index.And(c.fill)
 	index.Filter(func(idx uint32) (match bool) {
-		if idx < uint32(len(c.data)) {
-			if s, ok := c.LoadString(idx); ok {
-				return predicate(s)
-			}
-		}
-		return false
+		return idx < uint32(len(c.data)) && predicate(c.data[idx].(string))
 	})
 }
 

--- a/commit/commit_test.go
+++ b/commit/commit_test.go
@@ -13,23 +13,25 @@ import (
 
 func TestCommits(t *testing.T) {
 	commit1 := Commit{
-		Type:    TypeDelete,
+		Type:    Delete,
 		Deletes: bitmap.Bitmap{0xff},
 	}
 	commit2 := Commit{
-		Type:    TypeStore,
-		Column:  "test",
-		Updates: []Update{{Type: Put, Index: 5, Value: "hi"}},
+		Type: Store,
+		Updates: []Updates{{
+			Column: "test",
+			Update: []Update{{Type: Put, Index: 5, Value: "hi"}},
+		}},
 	}
 	commit3 := Commit{
-		Type:    TypeInsert,
+		Type:    Insert,
 		Inserts: bitmap.Bitmap{0xaa},
 	}
 
 	// Assert types
-	assert.Equal(t, TypeDelete, commit1.Type)
-	assert.Equal(t, TypeStore, commit2.Type)
-	assert.Equal(t, TypeInsert, commit3.Type)
+	assert.Equal(t, Delete, commit1.Type)
+	assert.Equal(t, Store, commit2.Type)
+	assert.Equal(t, Insert, commit3.Type)
 
 	// Clone and assert
 	clone1 := commit1.Clone()
@@ -44,8 +46,17 @@ func TestCommits(t *testing.T) {
 }
 
 func TestType(t *testing.T) {
-	assert.Equal(t, "store", TypeStore.String())
-	assert.Equal(t, "delete", TypeDelete.String())
-	assert.Equal(t, "insert", TypeInsert.String())
-	assert.Equal(t, "invalid", Type(10).String())
+	assert.Equal(t, "store", Type(1).String())
+	assert.Equal(t, "insert", Type(2).String())
+	assert.Equal(t, "store,insert", Type(3).String())
+	assert.Equal(t, "delete", Type(4).String())
+	assert.Equal(t, "store,delete", Type(5).String())
+	assert.Equal(t, "insert,delete", Type(6).String())
+	assert.Equal(t, "store,insert,delete", Type(7).String())
+	assert.Equal(t, "invalid", Type(8).String())
+
+	c := Commit{
+		Type: Type(6),
+	}
+	assert.True(t, c.Is(Delete))
 }

--- a/commit/writer.go
+++ b/commit/writer.go
@@ -18,9 +18,6 @@ type Channel chan Commit
 
 // Write clones the commit and writes it into the writer
 func (w *Channel) Write(commit Commit) error {
-	//cloned := commit.Clone()
-	//	commit.Close()
-
 	*w <- commit.Clone()
 	return nil
 }

--- a/commit/writer_test.go
+++ b/commit/writer_test.go
@@ -13,11 +13,11 @@ import (
 func TestWriterChannel(t *testing.T) {
 	w := make(Channel, 1)
 	w.Write(Commit{
-		Type:    TypeDelete,
+		Type:    Delete,
 		Deletes: bitmap.Bitmap{0xff},
 	})
 
 	out := <-w
-	assert.Equal(t, TypeDelete, out.Type)
+	assert.Equal(t, Delete, out.Type)
 	assert.Equal(t, bitmap.Bitmap{0xff}, out.Deletes)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kelindar/bitmap v1.0.8
+	github.com/kelindar/bitmap v1.0.9
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/kelindar/bitmap v1.0.8 h1:WNyrcEI3g67LHhltWnRDOvxlIQ+gr36/bpXuMVeyEvE=
-github.com/kelindar/bitmap v1.0.8/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
+github.com/kelindar/bitmap v1.0.9 h1:jVaK6cdq9uvjK0ZsZT6oLRCfad1KnZLRcAWk99b4Z6Q=
+github.com/kelindar/bitmap v1.0.9/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
 github.com/klauspost/cpuid/v2 v2.0.6 h1:dQ5ueTiftKxp0gyjKSx5+8BtPWkyQbd95m8Gys/RarI=
 github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/txn_cursor.go
+++ b/txn_cursor.go
@@ -128,7 +128,7 @@ func (cur *Cursor) Delete() {
 // Update updates a column value for the current item. The actual operation
 // will be queued and executed once the current the transaction completes.
 func (cur *Cursor) Update(value interface{}) {
-	cur.txn.updates[cur.update].update = append(cur.txn.updates[cur.update].update, commit.Update{
+	cur.txn.updates[cur.update].Update = append(cur.txn.updates[cur.update].Update, commit.Update{
 		Type:  commit.Put,
 		Index: cur.idx,
 		Value: value,
@@ -138,7 +138,7 @@ func (cur *Cursor) Update(value interface{}) {
 // Add atomically increments/decrements the current value by the specified amount. Note
 // that this only works for numerical values and the type of the value must match.
 func (cur *Cursor) Add(amount interface{}) {
-	cur.txn.updates[cur.update].update = append(cur.txn.updates[cur.update].update, commit.Update{
+	cur.txn.updates[cur.update].Update = append(cur.txn.updates[cur.update].Update, commit.Update{
 		Type:  commit.Add,
 		Index: cur.idx,
 		Value: amount,
@@ -149,8 +149,8 @@ func (cur *Cursor) Add(amount interface{}) {
 // will be queued and executed once the current the transaction completes.
 func (cur *Cursor) UpdateAt(column string, value interface{}) {
 	for i, c := range cur.txn.updates {
-		if c.name == column {
-			cur.txn.updates[i].update = append(c.update, commit.Update{
+		if c.Column == column {
+			cur.txn.updates[i].Update = append(c.Update, commit.Update{
 				Type:  commit.Put,
 				Index: cur.idx,
 				Value: value,
@@ -160,9 +160,9 @@ func (cur *Cursor) UpdateAt(column string, value interface{}) {
 	}
 
 	// Create a new update queue
-	cur.txn.updates = append(cur.txn.updates, updateQueue{
-		name: column,
-		update: []commit.Update{{
+	cur.txn.updates = append(cur.txn.updates, commit.Updates{
+		Column: column,
+		Update: []commit.Update{{
 			Type:  commit.Put,
 			Index: cur.idx,
 			Value: value,
@@ -174,8 +174,8 @@ func (cur *Cursor) UpdateAt(column string, value interface{}) {
 // that this only works for numerical values and the type of the value must match.
 func (cur *Cursor) AddAt(column string, amount interface{}) {
 	for i, c := range cur.txn.updates {
-		if c.name == column {
-			cur.txn.updates[i].update = append(c.update, commit.Update{
+		if c.Column == column {
+			cur.txn.updates[i].Update = append(c.Update, commit.Update{
 				Type:  commit.Add,
 				Index: cur.idx,
 				Value: amount,
@@ -185,9 +185,9 @@ func (cur *Cursor) AddAt(column string, amount interface{}) {
 	}
 
 	// Create a new update queue
-	cur.txn.updates = append(cur.txn.updates, updateQueue{
-		name: column,
-		update: []commit.Update{{
+	cur.txn.updates = append(cur.txn.updates, commit.Updates{
+		Column: column,
+		Update: []commit.Update{{
 			Type:  commit.Add,
 			Index: cur.idx,
 			Value: amount,


### PR DESCRIPTION
This PR contains a couple of changes:

- Refactored `Commit` structure which now contains all of the updates, inserts and deletes for a transaction. 
- Added a special case for insert to speed up bulk insertion, which seems to be now more or less linear (around 1 million inserts per second on the small example).
- Fixed builds on non `amd64` architectures.