### PR TITLE
Bitmap to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,8 @@ Let's first examine the `Range()` method. In the example below we select all of 
 
 ```go
 players.Query(func(txn *Txn) error {
-	txn.With("rogue").Range("name", func(v column.Cursor) bool {
+	txn.With("rogue").Range("name", func(v column.Cursor) {
 		println("rogue name ", v.String()) // Prints the name
-		return true
 	})
 	return nil
 })
@@ -175,10 +174,9 @@ Now, what if you need two columns? The range only allows you to quickly select a
 
 ```go
 players.Query(func(txn *Txn) error {
-	txn.With("rogue").Range("name", func(v column.Cursor) bool {
+	txn.With("rogue").Range("name", func(v column.Cursor) {
 		println("rogue name ", v.String())    // Prints the name
 		println("rogue age ", v.IntAt("age")) // Prints the age
-		return true
 	})
 	return nil
 })
@@ -214,10 +212,9 @@ In the example below we're selecting all of the rogues and updating both their b
 
 ```go
 players.Query(func(txn *Txn) error {
-	txn.With("rogue").Range("balance", func(v column.Cursor) bool {
+	txn.With("rogue").Range("balance", func(v column.Cursor) {
 		v.Update(10.0)        // Update the "balance" to 10.0
 		v.UpdateAt("age", 50) // Update the "age" to 50
-		return true
 	}) // Select the balance
 	return nil
 })
@@ -227,9 +224,8 @@ In certain cases, you might want to atomically increment or decrement numerical 
 
 ```go
 players.Query(func(txn *Txn) error {
-	txn.With("rogue").Range("balance", func(v column.Cursor) bool {
+	txn.With("rogue").Range("balance", func(v column.Cursor) {
 		v.Add(500.0) // Increment the "balance" by 500
-		return true
 	})
 	return nil
 })
@@ -254,11 +250,10 @@ On an interestig node, since `expire` column which is automatically added to eac
 
 ```go
 players.Query(func(txn *column.Txn) error {
-	return txn.Range("expire", func(v column.Cursor) bool {
+	return txn.Range("expire", func(v column.Cursor) {
 		oldExpire := time.Unix(0, v.Int()) // Convert expiration to time.Time
 		newExpire := expireAt.Add(1 * time.Hour).UnixNano()  // Add some time
 		v.Update(newExpire)
-		return true
 	})
 })
 ```
@@ -270,9 +265,8 @@ Transactions allow for isolation between two concurrent operations. In fact, all
 ```go
 // Range over all of the players and update (successfully their balance)
 players.Query(func(txn *column.Txn) error {
-	txn.Range("balance", func(v column.Cursor) bool {
+	txn.Range("balance", func(v column.Cursor) {
 		v.Update(10.0) // Update the "balance" to 10.0
-		return true
 	})
 
 	// No error, transaction will be committed
@@ -285,9 +279,8 @@ Now, in this example, we try to update balance but a query callback returns an e
 ```go
 // Range over all of the players and update (successfully their balance)
 players.Query(func(txn *column.Txn) error {
-	txn.Range("balance", func(v column.Cursor) bool {
+	txn.Range("balance", func(v column.Cursor) {
 		v.Update(10.0) // Update the "balance" to 10.0
-		return true
 	})
 
 	// Returns an error, transaction will be rolled back
@@ -398,9 +391,8 @@ func main(){
 	// Same condition as above, but we also select the actual names of those 
 	// players and iterate through them.
 	players.Query(func(txn *column.Txn) error {
-		txn.With("human", "mage", "old").Range("name", func(v column.Cursor) bool {
+		txn.With("human", "mage", "old").Range("name", func(v column.Cursor) {
 			println(v.String()) // prints the name
-			return true
 		}) // The column to select
 		return nil
 	})
@@ -428,31 +420,31 @@ When testing for larger collections, I added a small example (see `examples` fol
 
 ```
 running insert of 20000000 rows...
--> insert took 22.7740005s
-
-running full scan of age >= 30...
--> result = 10200000
--> full scan took 171.712196ms
-
-running full scan of class == "rogue"...
--> result = 7160000
--> full scan took 199.24443ms
-
-running indexed query of human mages...
--> result = 1360000
--> indexed query took 574µs
-
-running indexed query of human female mages...
--> result = 640000
--> indexed query took 747.148µs
-
-running update of balance of everyone...
--> updated 20000000 rows
--> update took 317.528908ms
-
-running update of age of mages...
--> updated 6040000 rows
--> update took 98.655836ms
+-> insert took 22.6758949s                      
+                                                
+running full scan of age >= 30...               
+-> result = 10200000                            
+-> full scan took 71.334496ms                   
+                                                
+running full scan of class == "rogue"...        
+-> result = 7160000                             
+-> full scan took 88.987218ms                   
+                                                
+running indexed query of human mages...         
+-> result = 1360000                             
+-> indexed query took 541.126µs                 
+                                                
+running indexed query of human female mages...  
+-> result = 640000                              
+-> indexed query took 724.593µs                 
+                                                
+running update of balance of everyone...        
+-> updated 20000000 rows                        
+-> update took 301.445804ms                     
+                                                
+running update of age of mages...               
+-> updated 6040000 rows                         
+-> update took 95.673186ms
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -405,15 +405,15 @@ The benchmarks below were ran on a collection of **100,000 items** containing a 
 
 ```
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkCollection/insert-8          5545016       216.8 ns/op       18 B/op    0 allocs/op
-BenchmarkCollection/fetch-8          27272726        43.61 ns/op       0 B/op    0 allocs/op
-BenchmarkCollection/scan-8                648   1844623 ns/op        147 B/op    0 allocs/op
-BenchmarkCollection/count-8           1000000      1107 ns/op          0 B/op    0 allocs/op
-BenchmarkCollection/range-8             10000    102549 ns/op          9 B/op    0 allocs/op
-BenchmarkCollection/update-at-8       4316584       280.7 ns/op        0 B/op    0 allocs/op
-BenchmarkCollection/update-all-8          826   1379693 ns/op      53068 B/op    0 allocs/op
-BenchmarkCollection/delete-at-8       7059126       169.1 ns/op        0 B/op    0 allocs/op
-BenchmarkCollection/delete-all-8       196734      6294 ns/op          0 B/op    0 allocs/op
+BenchmarkCollection/insert-8         5439637      221.3 ns/op      18 B/op     0 allocs/op
+BenchmarkCollection/fetch-8         23985608      48.55 ns/op       0 B/op     0 allocs/op
+BenchmarkCollection/scan-8              1845     689796 ns/op      25 B/op     0 allocs/op
+BenchmarkCollection/count-8          1000000       1133 ns/op       0 B/op     0 allocs/op
+BenchmarkCollection/range-8            10000     107436 ns/op      10 B/op     0 allocs/op
+BenchmarkCollection/update-at-8      4171920      286.7 ns/op       0 B/op     0 allocs/op
+BenchmarkCollection/update-all-8         837    1312193 ns/op   52392 B/op     0 allocs/op
+BenchmarkCollection/delete-at-8      7141628      169.9 ns/op       0 B/op     0 allocs/op
+BenchmarkCollection/delete-all-8      189722       6322 ns/op       0 B/op     0 allocs/op
 ```
 
 When testing for larger collections, I added a small example (see `examples` folder) and ran it with **20 million rows** inserted, each entry has **12 columns and 4 indexes** that need to be calculated, and a few queries and scans around them.

--- a/collection.go
+++ b/collection.go
@@ -278,11 +278,10 @@ func (c *Collection) vacuum(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			now := time.Now().UnixNano()
 			c.Query(func(txn *Txn) error {
-				return txn.With(expireColumn).Range(expireColumn, func(v Cursor) bool {
+				return txn.With(expireColumn).Range(expireColumn, func(v Cursor) {
 					if expirateAt := v.Int(); expirateAt != 0 && now >= v.Int() {
 						v.Delete()
 					}
-					return true
 				})
 			})
 		}

--- a/collection_test.go
+++ b/collection_test.go
@@ -211,7 +211,7 @@ func runReplication(t *testing.T, updates, inserts int) {
 				case 1:
 					primary.UpdateAt(offset, "int32", rand.Int31n(100000))
 				case 2:
-					primary.UpdateAt(offset, "string", fmt.Sprintf("hi %v", rand.Int31n(100)))
+					primary.UpdateAt(offset, "string", fmt.Sprintf("hi %v", rand.Int31n(10)))
 				}
 
 				// Randomly delete an item

--- a/collection_test.go
+++ b/collection_test.go
@@ -21,15 +21,15 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkCollection/insert-8         	 5531546	       215.9 ns/op	      18 B/op	       0 allocs/op
-BenchmarkCollection/fetch-8          	23749724	        44.97 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/scan-8           	     855	   1388532 ns/op	      88 B/op	       0 allocs/op
-BenchmarkCollection/count-8          	 1000000	      1081 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/range-8          	   10000	    100833 ns/op	      14 B/op	       0 allocs/op
-BenchmarkCollection/update-at-8      	 4225484	       281.7 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/update-all-8     	     830	   1388480 ns/op	  105714 B/op	       0 allocs/op
-BenchmarkCollection/delete-at-8      	 6928646	       171.9 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/delete-all-8     	  180884	      6373 ns/op	       1 B/op	       0 allocs/op
+BenchmarkCollection/insert-8         	 5439637	       221.3 ns/op	      18 B/op	       0 allocs/op
+BenchmarkCollection/fetch-8          	23985608	        48.55 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/scan-8           	    1845	    689796 ns/op	      25 B/op	       0 allocs/op
+BenchmarkCollection/count-8          	 1000000	      1133 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/range-8          	   10000	    107436 ns/op	      10 B/op	       0 allocs/op
+BenchmarkCollection/update-at-8      	 4171920	       286.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/update-all-8     	     837	   1312193 ns/op	   52392 B/op	       0 allocs/op
+BenchmarkCollection/delete-at-8      	 7141628	       169.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/delete-all-8     	  189722	      6322 ns/op	       0 B/op	       0 allocs/op
 */
 func BenchmarkCollection(b *testing.B) {
 	amount := 100000
@@ -100,10 +100,9 @@ func BenchmarkCollection(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			players.Query(func(txn *Txn) error {
-				txn.With("human", "mage", "old").Range("name", func(v Cursor) bool {
+				txn.With("human", "mage", "old").Range("name", func(v Cursor) {
 					count++
 					name = v.String()
-					return true
 				})
 				return nil
 			})
@@ -124,9 +123,8 @@ func BenchmarkCollection(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			players.Query(func(txn *Txn) error {
-				txn.Range("balance", func(v Cursor) bool {
+				txn.Range("balance", func(v Cursor) {
 					v.Update(1.0)
-					return true
 				})
 				return nil
 			})
@@ -236,7 +234,7 @@ func runReplication(t *testing.T, updates, inserts int) {
 		// Check if replica and primary are the same
 		assert.Equal(t, primary.Count(), replica.Count())
 		primary.Query(func(txn *Txn) error {
-			return txn.Range("float64", func(v Cursor) bool {
+			return txn.Range("float64", func(v Cursor) {
 				v1, v2 := v.FloatAt("float64"), v.IntAt("int32")
 				if v1 != 0 {
 					clone, _ := replica.Fetch(v.idx)
@@ -247,7 +245,6 @@ func runReplication(t *testing.T, updates, inserts int) {
 					clone, _ := replica.Fetch(v.idx)
 					assert.Equal(t, v.IntAt("int32"), clone.IntAt("int32"))
 				}
-				return true
 			})
 		})
 	})
@@ -329,10 +326,9 @@ func TestExpire(t *testing.T) {
 	// Insert an object
 	col.InsertWithTTL(obj, time.Microsecond)
 	col.Query(func(txn *Txn) error {
-		return txn.Range(expireColumn, func(v Cursor) bool {
+		return txn.Range(expireColumn, func(v Cursor) {
 			expireAt := time.Unix(0, v.Int())
 			v.Update(expireAt.Add(1 * time.Microsecond).UnixNano())
-			return true
 		})
 	})
 	assert.Equal(t, 1, col.Count())

--- a/examples/million/main.go
+++ b/examples/million/main.go
@@ -65,10 +65,9 @@ func main() {
 	measure("update", "balance of everyone", func() {
 		updates := 0
 		players.Query(func(txn *column.Txn) error {
-			return txn.Range("balance", func(v column.Cursor) bool {
+			return txn.Range("balance", func(v column.Cursor) {
 				updates++
 				v.Update(1000.0)
-				return true
 			})
 		})
 		fmt.Printf("-> updated %v rows\n", updates)
@@ -78,10 +77,9 @@ func main() {
 	measure("update", "age of mages", func() {
 		updates := 0
 		players.Query(func(txn *column.Txn) error {
-			return txn.With("mage").Range("age", func(v column.Cursor) bool {
+			return txn.With("mage").Range("age", func(v column.Cursor) {
 				updates++
 				v.Update(99.0)
-				return true
 			})
 		})
 		fmt.Printf("-> updated %v rows\n", updates)
@@ -91,10 +89,9 @@ func main() {
 	measure("update", "name of males", func() {
 		updates := 0
 		players.Query(func(txn *column.Txn) error {
-			return txn.With("male").Range("name", func(v column.Cursor) bool {
+			return txn.With("male").Range("name", func(v column.Cursor) {
 				updates++
 				v.Update("Sir " + v.String())
-				return true
 			})
 		})
 		fmt.Printf("-> updated %v rows\n", updates)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -41,9 +41,8 @@ func main() {
 
 	// Run an indexed query
 	players.Query(func(txn *column.Txn) error {
-		return txn.With("human", "mage", "old").Range("name", func(v column.Cursor) bool {
+		return txn.With("human", "mage", "old").Range("name", func(v column.Cursor) {
 			println("human old mage", v.String())
-			return true
 		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kelindar/bitmap v1.0.12
+	github.com/kelindar/bitmap v1.1.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/kelindar/bitmap v1.0.12 h1:MD696wPzddmfP/XrSm+kApsfVNJ5muR/2Sb2VAf+8QE=
-github.com/kelindar/bitmap v1.0.12/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
+github.com/kelindar/bitmap v1.1.0 h1:67PfkHFb+II2HQdeKrPugxMC7fZFEdKq31X+AOaHDq0=
+github.com/kelindar/bitmap v1.1.0/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
 github.com/klauspost/cpuid/v2 v2.0.6 h1:dQ5ueTiftKxp0gyjKSx5+8BtPWkyQbd95m8Gys/RarI=
 github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/txn_test.go
+++ b/txn_test.go
@@ -20,10 +20,9 @@ func TestFind(t *testing.T) {
 			return v == "mage"
 		}).WithUint("age", func(v uint64) bool {
 			return v >= 30
-		}).Range("name", func(v Cursor) bool {
+		}).Range("name", func(v Cursor) {
 			count++
 			assert.NotEmpty(t, v.String())
-			return true
 		})
 		return nil
 	})
@@ -111,8 +110,8 @@ func TestIndexInvalid(t *testing.T) {
 	})
 
 	assert.Error(t, players.Query(func(txn *Txn) error {
-		return txn.Range("invalid-column", func(v Cursor) bool {
-			return true
+		return txn.Range("invalid-column", func(v Cursor) {
+			return
 		})
 	}))
 
@@ -126,9 +125,9 @@ func TestIndexInvalid(t *testing.T) {
 	})
 
 	assert.NoError(t, players.Query(func(txn *Txn) error {
-		return txn.Range("balance", func(v Cursor) bool {
+		return txn.Range("balance", func(v Cursor) {
 			v.AddAt("invalid-column", 1)
-			return true
+			return
 		})
 	}))
 
@@ -187,7 +186,7 @@ func TestIndexed(t *testing.T) {
 	// Check the index value
 	players.Query(func(txn *Txn) error {
 		txn.With("human", "mage", "old").
-			Select(func(v Selector) bool {
+			Select(func(v Selector) {
 				assert.True(t, v.FloatAt("age") >= 30)
 				assert.True(t, v.IntAt("age") >= 30)
 				assert.True(t, v.UintAt("age") >= 30)
@@ -195,7 +194,6 @@ func TestIndexed(t *testing.T) {
 				assert.True(t, v.BoolAt("old"))
 				assert.Equal(t, "mage", v.StringAt("class"))
 				assert.False(t, v.BoolAt("xxx"))
-				return true
 			})
 		return nil
 	})
@@ -204,26 +202,22 @@ func TestIndexed(t *testing.T) {
 	players.Query(func(txn *Txn) error {
 		result := txn.With("human", "mage", "old")
 
-		result.Range("age", func(v Cursor) bool {
+		result.Range("age", func(v Cursor) {
 			assert.True(t, v.Float() >= 30)
 			assert.True(t, v.Int() >= 30)
 			assert.True(t, v.Uint() >= 30)
-			return true
 		})
 
-		result.Range("old", func(v Cursor) bool {
+		result.Range("old", func(v Cursor) {
 			assert.True(t, v.Value().(bool))
 			assert.True(t, v.Bool())
-			//	assert.Equal(t, "", v.String())
-			return true
 		})
 
-		result.Range("class", func(v Cursor) bool {
+		result.Range("class", func(v Cursor) {
 			//assert.Equal(t, "mage", v.String())
 			assert.Equal(t, float64(0), v.Float())
 			assert.Equal(t, int64(0), v.Int())
 			assert.Equal(t, uint64(0), v.Uint())
-			return true
 		})
 		return nil
 	})
@@ -253,9 +247,8 @@ func TestUpdate(t *testing.T) {
 
 	// Make everyone poor
 	players.Query(func(txn *Txn) error {
-		txn.Range("balance", func(v Cursor) bool {
+		txn.Range("balance", func(v Cursor) {
 			v.Update(1.0)
-			return true
 		})
 		return nil
 	})
@@ -277,9 +270,8 @@ func TestUpdate(t *testing.T) {
 
 	// Make everyone rich
 	players.Query(func(txn *Txn) error {
-		txn.Range("balance", func(v Cursor) bool {
+		txn.Range("balance", func(v Cursor) {
 			v.Update(5000.0)
-			return true
 		})
 		return nil
 	})
@@ -292,9 +284,8 @@ func TestUpdate(t *testing.T) {
 
 	// Try out the rollback
 	players.Query(func(txn *Txn) error {
-		txn.Range("balance", func(v Cursor) bool {
+		txn.Range("balance", func(v Cursor) {
 			v.Update(1.0)
-			return true
 		})
 		return fmt.Errorf("trigger rollback")
 	})
@@ -308,9 +299,8 @@ func TestUpdate(t *testing.T) {
 	// Reset balance back to zero
 	println("reset balance")
 	players.Query(func(txn *Txn) error {
-		return txn.Range("balance", func(v Cursor) bool {
+		return txn.Range("balance", func(v Cursor) {
 			v.Update(0.0)
-			return true
 		})
 	})
 
@@ -323,10 +313,9 @@ func TestUpdate(t *testing.T) {
 	// Increment balance 30 times by 100+100 = 6000
 	players.Query(func(txn *Txn) error {
 		for i := 0; i < 30; i++ {
-			txn.Range("balance", func(v Cursor) bool {
+			txn.Range("balance", func(v Cursor) {
 				v.Add(100.0)
 				v.AddAt("balance", 100.0)
-				return true
 			})
 			txn.commit()
 		}
@@ -335,9 +324,8 @@ func TestUpdate(t *testing.T) {
 
 	// Everyone should now be rich and the indexes updated
 	players.Query(func(txn *Txn) error {
-		txn.Range("balance", func(v Cursor) bool {
+		txn.Range("balance", func(v Cursor) {
 			assert.Equal(t, 6000.0, v.Float())
-			return true
 		})
 
 		assert.Equal(t, 245, txn.With("rich").Count())


### PR DESCRIPTION
This PR upgrades the bitmap dependency which has performance improvements to both `Range()` and `Filter()` methods by roughly 20% and 5% respectively. Interestingly, this specific benchmark is actually 50% faster.

```go
players.Query(func(txn *Txn) error {
   txn.WithString("race", func(v string) bool {
       return v == "human"
   }).WithString("class", func(v string) bool {
       return v == "mage"
   }).WithFloat("age", func(v float64) bool {
       return v >= 30
   }).Count()
    return nil
})
```

The reason being is that the second and third scans contain a lot of "holes" in the bitmap and the new implementation quickly skips empty pages and consecutive zero bits.