### PR TITLE
Cleanup commit

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -297,7 +297,7 @@ func (c *Collection) vacuum(ctx context.Context, interval time.Duration) {
 // Replay replays a commit on a collection, applying the changes.
 func (c *Collection) Replay(change commit.Commit) error {
 	return c.Query(func(txn *Txn) error {
-		txn.dirty = change.Dirty
+		txn.dirty.Set(change.Chunk)
 		for i := range change.Updates {
 			if !change.Updates[i].IsEmpty() {
 				txn.updates = append(txn.updates, change.Updates[i])

--- a/collection_test.go
+++ b/collection_test.go
@@ -23,15 +23,15 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkCollection/insert-8         	    1742	    575151 ns/op	    1398 B/op	       1 allocs/op
-BenchmarkCollection/fetch-8          	29648077	        37.81 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/scan-8           	    1974	    628406 ns/op	      89 B/op	       0 allocs/op
-BenchmarkCollection/count-8          	  855321	      1432 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/range-8          	   16892	     70650 ns/op	       9 B/op	       0 allocs/op
-BenchmarkCollection/update-at-8      	 3576921	       344.2 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/update-all-8     	    1165	   1002941 ns/op	    4074 B/op	       0 allocs/op
-BenchmarkCollection/delete-at-8      	 8455353	       134.4 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/delete-all-8     	 2398639	       499.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/insert-8         	    1861	    582483 ns/op	    1249 B/op	       1 allocs/op
+BenchmarkCollection/fetch-8          	30763866	        38.66 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/scan-8           	    1906	    618875 ns/op	     102 B/op	       0 allocs/op
+BenchmarkCollection/count-8          	  748754	      1416 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/range-8          	   16807	     71049 ns/op	       7 B/op	       0 allocs/op
+BenchmarkCollection/update-at-8      	 3753175	       330.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/update-all-8     	    1156	    994670 ns/op	    4133 B/op	       0 allocs/op
+BenchmarkCollection/delete-at-8      	 8459896	       146.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/delete-all-8     	 2460322	       478.9 ns/op	       0 B/op	       0 allocs/op
 */
 func BenchmarkCollection(b *testing.B) {
 	b.Run("insert", func(b *testing.B) {

--- a/commit/commit.go
+++ b/commit/commit.go
@@ -3,25 +3,18 @@
 
 package commit
 
-import (
-	"github.com/kelindar/bitmap"
-)
-
 // --------------------------- Commit ----------------------------
 
-// Commit represents an individual transaction commit. If multiple columns are committed
+// Commit represents an individual transaction commit. If multiple chunks are committed
 // in the same transaction, it would result in multiple commits per transaction.
 type Commit struct {
-	Chunk   uint32        // The chunk number
-	Updates []*Buffer     // The update buffers
-	Dirty   bitmap.Bitmap // The dirty bitmap (TODO: rebuild instead?)
+	Chunk   uint32    // The chunk number
+	Updates []*Buffer // The update buffers
 }
 
 // Clone clones a commit into a new one
 func (c *Commit) Clone() (clone Commit) {
 	clone.Chunk = c.Chunk
-	c.Dirty.Clone(&clone.Dirty)
-
 	for _, u := range c.Updates {
 		if len(u.buffer) > 0 {
 			clone.Updates = append(clone.Updates, u.Clone())

--- a/commit/commit_test.go
+++ b/commit/commit_test.go
@@ -6,13 +6,11 @@ package commit
 import (
 	"testing"
 
-	"github.com/kelindar/bitmap"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCommitClone(t *testing.T) {
 	commit := Commit{
-		Dirty: bitmap.Bitmap{0x1},
 		Updates: []*Buffer{{
 			buffer: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f},
 			chunks: []header{{

--- a/commit/writer_test.go
+++ b/commit/writer_test.go
@@ -6,16 +6,15 @@ package commit
 import (
 	"testing"
 
-	"github.com/kelindar/bitmap"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWriterChannel(t *testing.T) {
 	w := make(Channel, 1)
 	w.Write(Commit{
-		Dirty: bitmap.Bitmap{0xff},
+		Chunk: 123,
 	})
 
 	out := <-w
-	assert.Equal(t, bitmap.Bitmap{0xff}, out.Dirty)
+	assert.Equal(t, 123, int(out.Chunk))
 }

--- a/txn_cursor.go
+++ b/txn_cursor.go
@@ -162,7 +162,6 @@ func (cur *Cursor) Bool() bool {
 // Delete deletes the current item. The actual operation will be queued and
 // executed once the current the transaction completes.
 func (cur *Cursor) Delete() {
-	cur.txn.dirty.Set(cur.idx >> chunkShift)
 	cur.txn.deleteAt(cur.idx)
 }
 


### PR DESCRIPTION
This is a cleanup PR, removes `dirty` bitmap from the `Commit` struct, further simplifying the flow. Also, when deleting/inserting there is no need to set the bit in the dirty bitmap either, since now we can re-compute it from the update buffers just before the commit.