### PR TITLE
Added more tests, removed unnecessary code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.17
 require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/kelindar/async v1.0.0
-	github.com/kelindar/bitmap v1.1.0
+	github.com/kelindar/bitmap v1.1.1
+	github.com/kelindar/rand v1.0.2
 	github.com/kelindar/smutex v1.0.0
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kelindar/rand v1.0.2
 	github.com/klauspost/cpuid/v2 v2.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/kelindar/async v1.0.0 h1:oJiFAt3fVB/b5zVZKPBU+pP9lR3JVyeox9pYlpdnIK8=
 github.com/kelindar/async v1.0.0/go.mod h1:bJRlwaRiqdHi+4dpVDNHdwgyRyk6TxpA21fByLf7hIY=
-github.com/kelindar/bitmap v1.1.0 h1:67PfkHFb+II2HQdeKrPugxMC7fZFEdKq31X+AOaHDq0=
-github.com/kelindar/bitmap v1.1.0/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
+github.com/kelindar/bitmap v1.1.1 h1:qgoVt+3r7RpvCQDXGOovDS/GrFVkFxSO5mbAMbEELKk=
+github.com/kelindar/bitmap v1.1.1/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
 github.com/kelindar/rand v1.0.2 h1:PKVCNdVENEb6/h8ZXWa56NDJX8r7zwXoYPgzGbT+7yA=
 github.com/kelindar/rand v1.0.2/go.mod h1:kEcA6wZSY1uBzo9j2BCH811NzngM0yRsCkF5GzY/cg8=
 github.com/kelindar/smutex v1.0.0 h1:+LIZYwPz+v3IWPOse764fNaVQGMVxKV6mbD6OWjQV3o=


### PR DESCRIPTION
This PR includes some fixes and a better error handling for the indexes:

- `CreateIndex` now requires column to be created before the index. Prior to this you could create an index on a `nil` column, which was a weird behaviour.
- `DropIndex` now has more validation.
- Replaced `fnv1` with `crc32` for `enum` column, to simplify the code a bit.