### PR TITLE
Improved UpdateAt and Fetch

### DIFF
--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -1,43 +1,44 @@
 # Concurrency Benchmark
 
 This is an example benchmark with various workloads (90% read / 10% write, etc) on a collection of 1 million elements with different goroutine pools. In this example we're combining two types of transactions:
- * Read transactions that query a random index and iterate over the results over a single column.
+ * Read transactions that update a random element (point-read).
  * Write transactions that update a random element (point-write).
 
 Note that the goal of this benchmark is to validate concurrency, not throughput this represents the current "best" case scenario when the updates are random and do less likely to incur contention. Reads, however quite often would hit the same chunks as only the index itself is randomized.
 
 ```
-90%-10%       1 procs      249,208,310 read/s        117 write/s
-90%-10%       8 procs    1,692,667,386 read/s        738 write/s
-90%-10%      16 procs    1,509,926,215 read/s        635 write/s
-90%-10%      32 procs    1,489,456,934 read/s        660 write/s
-90%-10%      64 procs    1,533,053,898 read/s        666 write/s
-90%-10%     128 procs    1,495,078,423 read/s        654 write/s
-90%-10%     256 procs    1,443,437,689 read/s        656 write/s
-90%-10%     512 procs    1,464,321,958 read/s        704 write/s
-90%-10%    1024 procs    1,495,877,020 read/s        635 write/s
-90%-10%    2048 procs    1,413,233,904 read/s        658 write/s
-90%-10%    4096 procs    1,376,644,077 read/s        743 write/s
-50%-50%       1 procs      236,528,133 read/s        861 write/s
-50%-50%       8 procs    1,589,501,618 read/s      6,335 write/s
-50%-50%      16 procs    1,607,166,585 read/s      6,484 write/s
-50%-50%      32 procs    1,575,200,925 read/s      6,438 write/s
-50%-50%      64 procs    1,432,978,587 read/s      5,808 write/s
-50%-50%     128 procs    1,181,986,760 read/s      4,606 write/s
-50%-50%     256 procs    1,529,174,062 read/s      6,180 write/s
-50%-50%     512 procs    1,472,102,974 read/s      5,961 write/s
-50%-50%    1024 procs    1,399,040,792 read/s      6,066 write/s
-50%-50%    2048 procs    1,295,570,830 read/s      5,919 write/s
-50%-50%    4096 procs    1,181,556,697 read/s      5,871 write/s
-10%-90%       1 procs      199,670,671 read/s      7,119 write/s
-10%-90%       8 procs    1,224,172,050 read/s     44,464 write/s
-10%-90%      16 procs    1,317,755,536 read/s     46,451 write/s
-10%-90%      32 procs    1,429,807,620 read/s     51,758 write/s
-10%-90%      64 procs    1,413,067,976 read/s     51,304 write/s
-10%-90%     128 procs    1,302,410,992 read/s     46,375 write/s
-10%-90%     256 procs    1,223,553,655 read/s     45,110 write/s
-10%-90%     512 procs    1,120,740,609 read/s     42,799 write/s
-10%-90%    1024 procs    1,071,064,037 read/s     41,519 write/s
-10%-90%    2048 procs    1,044,805,034 read/s     42,868 write/s
-10%-90%    4096 procs      877,312,822 read/s     42,910 write/s
+   WORK         PROCS              READS             WRITES
+90%-10%       1 procs       51,642 txn/s        5,884 txn/s
+90%-10%       8 procs      195,201 txn/s       21,803 txn/s
+90%-10%      16 procs      311,078 txn/s       34,519 txn/s
+90%-10%      32 procs      370,100 txn/s       41,225 txn/s
+90%-10%      64 procs      374,964 txn/s       41,582 txn/s
+90%-10%     128 procs      347,933 txn/s       38,589 txn/s
+90%-10%     256 procs      337,840 txn/s       37,329 txn/s
+90%-10%     512 procs      342,272 txn/s       37,692 txn/s
+90%-10%    1024 procs      339,367 txn/s       37,049 txn/s
+90%-10%    2048 procs      327,060 txn/s       35,568 txn/s
+90%-10%    4096 procs      314,160 txn/s       32,818 txn/s
+50%-50%       1 procs       28,944 txn/s       29,054 txn/s
+50%-50%       8 procs       59,487 txn/s       59,342 txn/s
+50%-50%      16 procs       70,271 txn/s       70,276 txn/s
+50%-50%      32 procs       70,067 txn/s       69,796 txn/s
+50%-50%      64 procs       61,443 txn/s       61,559 txn/s
+50%-50%     128 procs       54,985 txn/s       54,760 txn/s
+50%-50%     256 procs       53,684 txn/s       53,465 txn/s
+50%-50%     512 procs       62,488 txn/s       61,967 txn/s
+50%-50%    1024 procs       69,211 txn/s       68,090 txn/s
+50%-50%    2048 procs       74,262 txn/s       73,639 txn/s
+50%-50%    4096 procs       77,700 txn/s       75,452 txn/s
+10%-90%       1 procs        4,811 txn/s       43,825 txn/s
+10%-90%       8 procs        8,585 txn/s       77,136 txn/s
+10%-90%      16 procs        8,582 txn/s       77,260 txn/s
+10%-90%      32 procs        8,866 txn/s       79,127 txn/s
+10%-90%      64 procs        8,090 txn/s       73,265 txn/s
+10%-90%     128 procs        7,412 txn/s       67,985 txn/s
+10%-90%     256 procs        6,473 txn/s       58,903 txn/s
+10%-90%     512 procs        6,916 txn/s       61,835 txn/s
+10%-90%    1024 procs        7,989 txn/s       71,794 txn/s
+10%-90%    2048 procs        8,930 txn/s       78,657 txn/s
+10%-90%    4096 procs        9,231 txn/s       81,465 txn/s
 ```

--- a/txn.go
+++ b/txn.go
@@ -246,6 +246,17 @@ func (txn *Txn) Count() int {
 	return int(txn.index.Count())
 }
 
+// UpdateAt creates a cursor to a specific element that can be read or updated.
+func (txn *Txn) UpdateAt(index uint32, columnName string, fn func(v Cursor) error) error {
+	cursor, err := txn.cursorFor(columnName)
+	if err != nil {
+		return err
+	}
+
+	cursor.idx = index
+	return fn(cursor)
+}
+
 // ReadAt returns a selector for a specified index together with a boolean value that indicates
 // whether an element is present at the specified index or not.
 func (txn *Txn) ReadAt(index uint32) (Selector, bool) {

--- a/txn_test.go
+++ b/txn_test.go
@@ -469,3 +469,30 @@ func TestUninitializedSet(t *testing.T) {
 		})
 	}))
 }
+
+func TestUpdateAt(t *testing.T) {
+	c := NewCollection()
+	c.CreateColumn("col1", ForString())
+	index := c.Insert(map[string]interface{}{
+		"col1": "hello",
+	})
+
+	assert.NoError(t, c.UpdateAt(index, "col1", func(v Cursor) error {
+		v.SetString("hi")
+		return nil
+	}))
+
+	assert.True(t, c.SelectAt(index, func(v Selector) {
+		assert.Equal(t, "hi", v.StringAt("col1"))
+	}))
+}
+
+func TestUpdateAtInvalid(t *testing.T) {
+	c := NewCollection()
+	c.CreateColumn("col1", ForString())
+
+	assert.Error(t, c.UpdateAt(0, "col2", func(v Cursor) error {
+		v.SetString("hi")
+		return nil
+	}))
+}

--- a/txn_test.go
+++ b/txn_test.go
@@ -478,7 +478,7 @@ func TestUpdateAt(t *testing.T) {
 	})
 
 	assert.NoError(t, c.UpdateAt(index, "col1", func(v Cursor) error {
-		v.SetString("hi")
+		v.Set("hi")
 		return nil
 	}))
 


### PR DESCRIPTION
This PR introduces API changes:
 * `UpdateAt` on a collection level now takes a function delegate.
 * `Fetch` renamed to `SelectAt` and now also takes function delegate.

In addition, I changed the `bench` example to point transactions, and now instead of measuring individual rows modified, it measures transactions per second. These are point-reads and point-writes, very inefficient since it would create one transaction per row and does not benefit from bitmap indexing. 