### PR TITLE
Fixed point read latch

### DIFF
--- a/examples/bench/bench.go
+++ b/examples/bench/bench.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/crc32"
+	"math/bits"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -31,13 +31,13 @@ func main() {
 	createCollection(players, amount)
 
 	// This runs point query benchmarks
-	runBenchmark("Point Reads/Writes", func(writeTxn bool) (reads int, writes int) {
+	runBenchmark("Point Reads/Writes", func(v uint32, writeTxn bool) (reads int, writes int) {
 
 		// To avoid task granuarity problem, load up a bit more work on each
 		// of the goroutines, a few hundred reads should be enough to amortize
 		// the cost of scheduling goroutines, so we can actually test our code.
 		for i := 0; i < 1000; i++ {
-			offset := randN(amount - 1)
+			offset := randN(v, amount-1)
 			if writeTxn {
 				players.UpdateAt(offset, "balance", func(v column.Cursor) error {
 					v.SetFloat64(0)
@@ -56,7 +56,7 @@ func main() {
 }
 
 // runBenchmark runs a benchmark
-func runBenchmark(name string, fn func(bool) (int, int)) {
+func runBenchmark(name string, fn func(uint32, bool) (int, int)) {
 	fmt.Printf("Benchmarking %v ...\n", name)
 	fmt.Printf("%7v\t%6v\t%17v\t%13v\n", "WORK", "PROCS", "READ RATE", "WRITE RATE")
 	for _, workload := range []int{0, 10, 50, 90, 100} {
@@ -69,12 +69,12 @@ func runBenchmark(name string, fn func(bool) (int, int)) {
 			var reads, writes int64
 			var wg sync.WaitGroup
 			start := time.Now()
-			for time.Since(start) < time.Second {
+			for i := uint32(0); time.Since(start) < time.Second; i++ {
 				wg.Add(1)
 				work <- async.NewTask(func(ctx context.Context) (interface{}, error) {
 					defer wg.Done()
 
-					r, w := fn(chanceOf(workload))
+					r, w := fn(i, chanceOf(i, workload))
 					atomic.AddInt64(&reads, int64(r))
 					atomic.AddInt64(&writes, int64(w))
 					return nil, nil
@@ -145,21 +145,24 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 	return out
 }
 
-var epoch uint32
-
 // This random number generator not the most amazing one, but much better
 // than using math.Rand for our benchmarks, since it would create a lock
 // contention and bias the results.
-func randN(n int) uint32 {
-	v := atomic.AddUint32(&epoch, 1)
-	return crc32.ChecksumIEEE([]byte{
-		byte(v >> 24),
-		byte(v >> 16),
-		byte(v >> 8),
-		byte(v),
-	}) % uint32(n)
+func randN(v uint32, n int) uint32 {
+	return uint32(xxhash(v) % uint64(n))
 }
 
-func chanceOf(chance int) bool {
-	return randN(100) < uint32(chance)
+func chanceOf(v uint32, chance int) bool {
+	return randN(v, 100) < uint32(chance)
+}
+
+func xxhash(v uint32) uint64 {
+	packed := uint64(v) + uint64(v)<<32
+	x := packed ^ (0x1cad21f72c81017c ^ 0xdb979083e96dd4de)
+	x ^= bits.RotateLeft64(x, 49) ^ bits.RotateLeft64(x, 24)
+	x *= 0x9fb21c651e98df25
+	x ^= (x >> 35) + 4 // len
+	x *= 0x9fb21c651e98df25
+	x ^= (x >> 28)
+	return x
 }

--- a/txn.go
+++ b/txn.go
@@ -257,17 +257,10 @@ func (txn *Txn) UpdateAt(index uint32, columnName string, fn func(v Cursor) erro
 	return fn(cursor)
 }
 
-// ReadAt returns a selector for a specified index together with a boolean value that indicates
-// whether an element is present at the specified index or not.
-func (txn *Txn) ReadAt(index uint32) (Selector, bool) {
-	if !txn.index.Contains(index) {
-		return Selector{}, false
-	}
-
-	return Selector{
-		idx: index,
-		txn: txn,
-	}, true
+// SelectAt performs a selection on a specific row specified by its index. It returns
+// a boolean value indicating whether an element is present at the index or not.
+func (txn *Txn) SelectAt(index uint32, fn func(v Selector)) bool {
+	return txn.owner.SelectAt(index, fn)
 }
 
 // DeleteAt attempts to delete an item at the specified index for this transaction. If the item

--- a/txn_test.go
+++ b/txn_test.go
@@ -130,11 +130,8 @@ func TestIndexInvalid(t *testing.T) {
 	}))
 
 	players.Query(func(txn *Txn) error {
-		_, ok := txn.ReadAt(999999)
-		assert.False(t, ok)
-
-		_, ok = txn.ReadAt(0)
-		assert.True(t, ok)
+		assert.False(t, txn.SelectAt(999999, func(v Selector) {}))
+		assert.True(t, txn.SelectAt(0, func(v Selector) {}))
 		return nil
 	})
 


### PR DESCRIPTION
Fixed the latch of point read (`SelectAt()`) on both collection and the transaction. Transaction point read semantics were different, which is confusing. Now they are both essentially the same. I also removed completely lock contention from the benchmark, now using an interation number instead of atomic.

With this change, the point read now scales quite well. 

```
   WORK  PROCS          READ RATE          WRITE RATE
100%-0%      1   17,320,162 txn/s             0 txn/s
100%-0%      2   27,678,524 txn/s             0 txn/s
100%-0%      4   37,998,651 txn/s             0 txn/s
100%-0%      8   52,135,263 txn/s             0 txn/s
100%-0%     16   39,878,285 txn/s             0 txn/s
100%-0%     32   31,037,293 txn/s             0 txn/s
100%-0%     64   27,923,347 txn/s             0 txn/s
100%-0%    128   27,015,623 txn/s             0 txn/s
100%-0%    256   27,004,417 txn/s             0 txn/s
100%-0%    512   27,025,849 txn/s             0 txn/s
```