### PR TITLE
Added key column type

### DIFF
--- a/column.go
+++ b/column.go
@@ -80,6 +80,7 @@ var (
 	ForUint64  = makeUint64s
 	ForBool    = makeBools
 	ForEnum    = makeEnum
+	ForKey     = makeKey
 )
 
 // ForKind creates a new column instance for a specified reflect.Kind

--- a/commit/buffer.go
+++ b/commit/buffer.go
@@ -115,9 +115,9 @@ func (b *Buffer) PutAny(op OpType, idx uint32, value interface{}) {
 	case int32:
 		b.PutInt32(op, idx, v)
 	case int16:
-		b.PutUint16(op, idx, uint16(v))
+		b.PutInt16(op, idx, v)
 	case int8:
-		b.PutUint16(op, idx, uint16(v))
+		b.PutInt16(op, idx, int16(v))
 	case string:
 		b.PutString(op, idx, v)
 	case []byte:

--- a/examples/bench/bench.go
+++ b/examples/bench/bench.go
@@ -136,7 +136,7 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 	for i := 0; i < amount/len(data); i++ {
 		out.Query(func(txn *column.Txn) error {
 			for _, p := range data {
-				txn.Insert(p)
+				txn.InsertObject(p)
 			}
 			return nil
 		})

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,105 +1,45 @@
 # Example: Key/Value Cache
 
-Here's an example of how one might go about building a key-value cache using columnar storage. This code is kept simple on purpose and hence is not the most efficient one, but do note that it doesn't actually have any hash maps and uses exclusively bitmap indexing to retrieve keys.  
-
-## Implementation
-
-Three columns are created on the collection `key` for the key string itself, `val` for the string value to be cached and `crc` for the checksum/hash value of the key.
+This example demonstrates a `Key` column type that allows you to perform `O(1)` lookups over that. This can be used in the case where you do not have a specific offset for the entry.
 
 ```go
-db := column.NewCollection()
-db.CreateColumn("key", column.ForString())
-db.CreateColumn("val", column.ForString())
-db.CreateColumn("crc", column.ForUint64())
-```
-
-On top of `crc` column we create a number of bucket indices, in this example `100` buckets are created. Basically it functions as a transposed hash table when you think about it, but in this implementation the bucket size will vary - more items will result in larger buckets and larger search for the key. It's not ideal, but interesting for the sake of the exercice.
-
-```go
-for i := 0; i < buckets; i++ {
-    bucket := uint(i) // copy the value
-    db.CreateIndex(strconv.Itoa(i), "crc", func(r column.Reader) bool {
-        return r.Uint()%uint(buckets) == bucket
-    })
-}
-```
-
-Next, we also create a bitmap to act as a bloom filter. This allows us to quikcly check if a single key is present in the collection or not, and quickly skip search if it does not exist. It's helps to make the insertion not too slow for large numbers of elements stored in the cache.
-
-```go
-func (c *Cache) addToFilter(hash uint32) {
-	position := hash % uint32(len(c.bloom)*64)
-	c.bloom.Set(position)
+// Cache represents a key-value store
+type Cache struct {
+	store *column.Collection
 }
 
-func (c *Cache) checkFilter(hash uint32) bool {
-	position := hash % uint32(len(c.bloom)*64)
-	return c.bloom.Contains(position)
+// New creates a new key-value cache
+func New() *Cache {
+	db := column.NewCollection()
+	db.CreateColumn("key", column.ForKey())
+	db.CreateColumn("val", column.ForString())
+
+	return &Cache{
+		store: db,
+	}
 }
 
-```
-
-The search function is expressed with a single transaction. It computes the bucket, narrows down the search to the bucket using the bitmap index with the same name, then does a linear search within it to compare the hash. Once found, it selects the value and the index.
-
-```go
 // Get attempts to retrieve a value for a key
 func (c *Cache) Get(key string) (value string, found bool) {
-	hash := crc32.ChecksumIEEE([]byte(key))
-	value, idx := c.search(hash)
-	return value, idx >= 0
-}
-
-// search attempts to retrieve a value for a key. If the value is found, it returns
-// the actual value and its index in the collection. Otherwise, it returns -1.
-func (c *Cache) search(hash uint32) (value string, index int) {
-	index = -1
-
-	c.store.Query(func(txn *column.Txn) error {
-		bucketName := fmt.Sprintf("%d", hash%uint32(buckets))
-		return txn.
-			With(bucketName).
-			WithUint("crc", func(v uint64) bool {
-				return v == uint64(hash)
-			}).Range("val", func(v column.Cursor) {
-			value = v.String()
-			index = int(v.Index())
-		})
+	c.store.SelectAtKey(key, func(v column.Selector) {
+		value = v.StringAt("val")
+		found = true
 	})
 	return
 }
-```
 
-On the flip side, when you want to insert the key we simply check the bloom filter, and if it exists we perform a search and update the value if found. Otherwise, we add to the bloom filter and insert a new row.
-
-```go
 // Set updates or inserts a new value
 func (c *Cache) Set(key, value string) {
-	hash := crc32.ChecksumIEEE([]byte(key))
-
-	// First check if the value already exists, and update it if found.
-	if c.checkFilter(hash) {
-		if _, idx := c.search(hash); idx >= 0 {
-			c.store.UpdateAt(uint32(idx), "val", func(v column.Cursor) error {
-				v.SetString(value)
-				return nil
-			})
-			return
-		}
+	if err := c.store.UpdateAtKey(key, "val", func(v column.Cursor) error {
+		v.SetString(value)
+		return nil
+	}); err != nil {
+		panic(err)
 	}
-
-	// If not found, insert a new row
-	c.addToFilter(hash)
-	c.store.Insert(map[string]interface{}{
-		"key": key,
-		"val": value,
-		"crc": uint64(hash),
-	})
 }
 ```
 
 ## Some Results
-
-Below are some results for the cache, it first populates 50,000 items, which is kind of slow. Then, does 10 random searches and measures it. Here, since we have 100 buckets and 50,000 items the search would produce around 500 elements per retrieval, after the binary AND operation.
 
 ```
 running insert of 50000 rows...
@@ -108,45 +48,9 @@ running insert of 50000 rows...
 -> inserted 30000 rows
 -> inserted 40000 rows
 -> inserted 50000 rows
--> insert took 214.1031ms
+-> insert took 80.2478ms
 
-running query of user_10156...
-Hi, User 10156 true
--> query took 3.683µs
-
-running query of user_26245...
-Hi, User 26245 true
--> query took 3.862µs
-
-running query of user_4187...
-Hi, User 4187 true
--> query took 3.427µs
-
-running query of user_10333...
-Hi, User 10333 true
--> query took 3.529µs
-
-running query of user_22579...
-Hi, User 22579 true
--> query took 3.508µs
-
-running query of user_14530...
-Hi, User 14530 true
--> query took 3.352µs
-
-running query of user_11922...
-Hi, User 11922 true
--> query took 3.508µs
-
-running query of user_24969...
-Hi, User 24969 true
--> query took 3.542µs
-
-running query of user_44266...
-Hi, User 44266 true
--> query took 7.024µs
-
-running query of user_482...
-Hi, User 482 true
--> query took 3.503µs
+running query of user_11255...
+Hi, User 11255 true
+-> query took 1.271µs
 ```

--- a/examples/cache/cache.go
+++ b/examples/cache/cache.go
@@ -4,120 +4,40 @@
 package main
 
 import (
-	"fmt"
-	"hash/crc32"
-	"strconv"
-
-	"github.com/kelindar/bitmap"
 	"github.com/kelindar/column"
 )
 
-const buckets = 32
-
 // Cache represents a key-value store
 type Cache struct {
-	bloom bitmap.Bitmap // Our silly bloom filter
 	store *column.Collection
 }
 
 // New creates a new key-value cache
 func New() *Cache {
 	db := column.NewCollection()
-	db.CreateColumn("key", column.ForString())
+	db.CreateColumn("key", column.ForKey())
 	db.CreateColumn("val", column.ForString())
-	db.CreateColumn("crc", column.ForUint64())
-
-	// Create a bunch of buckets for faster retrieval
-	for i := 0; i < buckets; i++ {
-		db.CreateColumn(strconv.Itoa(i), column.ForBool())
-	}
 
 	return &Cache{
-		bloom: make(bitmap.Bitmap, 1<<16),
 		store: db,
 	}
 }
 
 // Get attempts to retrieve a value for a key
 func (c *Cache) Get(key string) (value string, found bool) {
-	value, idx := c.search([]byte(key))
-	return value, idx >= 0
-}
-
-// Set updates or inserts a new value
-func (c *Cache) Set(key, value string) {
-	k := []byte(key)
-
-	// First check if the value already exists, and update it if found.
-	if c.checkFilter(value) {
-		if _, idx := c.search([]byte(key)); idx >= 0 {
-			c.store.UpdateAt(uint32(idx), "val", func(v column.Cursor) error {
-				v.SetString(value)
-				return nil
-			})
-			return
-		}
-	}
-
-	// If not found, insert a new row
-	c.addToFilter(value)
-
-	h1 := fmt.Sprintf("%d", crc32.Checksum(k, hash1)%buckets)
-	h2 := fmt.Sprintf("%d", crc32.Checksum(k, hash2)%buckets)
-	h3 := fmt.Sprintf("%d", crc32.Checksum(k, hash3)%buckets)
-
-	c.store.Insert(map[string]interface{}{
-		"key": key,
-		"val": value,
-		"crc": uint64(crc32.ChecksumIEEE(k)),
-		h1:    true,
-		h2:    true,
-		h3:    true,
-	})
-}
-
-// search attempts to retrieve a value for a key. If the value is found, it returns
-// the actual value and its index in the collection. Otherwise, it returns -1.
-func (c *Cache) search(key []byte) (value string, index int) {
-	index = -1
-	h1 := fmt.Sprintf("%d", crc32.Checksum(key, hash1)%buckets)
-	h2 := fmt.Sprintf("%d", crc32.Checksum(key, hash2)%buckets)
-	h3 := fmt.Sprintf("%d", crc32.Checksum(key, hash3)%buckets)
-
-	hash := crc32.ChecksumIEEE([]byte(key))
-	c.store.Query(func(txn *column.Txn) error {
-		return txn.
-			With(h1, h2, h3).
-			WithUint("crc", func(v uint64) bool {
-				return v == uint64(hash)
-			}).Range("val", func(v column.Cursor) {
-			value = v.String()
-			index = int(v.Index())
-		})
+	c.store.SelectAtKey(key, func(v column.Selector) {
+		value = v.StringAt("val")
+		found = true
 	})
 	return
 }
 
-func (c *Cache) addToFilter(value string) {
-	b1, b2, b3 := bloomBits([]byte(value), len(c.bloom))
-	c.bloom.Set(b1)
-	c.bloom.Set(b2)
-	c.bloom.Set(b3)
-}
-
-func (c *Cache) checkFilter(value string) bool {
-	b1, b2, b3 := bloomBits([]byte(value), len(c.bloom))
-	return c.bloom.Contains(b1) && c.bloom.Contains(b2) && c.bloom.Contains(b3)
-}
-
-// Couple of hash functions for the bloom filter
-var hash1 = crc32.MakeTable(crc32.Koopman)
-var hash2 = crc32.MakeTable(crc32.Castagnoli)
-var hash3 = crc32.MakeTable(crc32.IEEE)
-
-func bloomBits(v []byte, length int) (uint32, uint32, uint32) {
-	size := uint32(length * 64)
-	return crc32.Checksum(v, hash1) % size,
-		crc32.Checksum(v, hash2) % size,
-		crc32.Checksum(v, hash3) % size
+// Set updates or inserts a new value
+func (c *Cache) Set(key, value string) {
+	if err := c.store.UpdateAtKey(key, "val", func(v column.Cursor) error {
+		v.SetString(value)
+		return nil
+	}); err != nil {
+		panic(err)
+	}
 }

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -27,12 +27,11 @@ func main() {
 		}
 	}, 1)
 
-	for i := 0; i < 10; i++ {
-		key := fmt.Sprintf("user_%d", xxrand.Intn(amount))
-		measure("query", key, func() {
-			fmt.Println(cache.Get(key))
-		}, 10000)
-	}
+	key := fmt.Sprintf("user_%d", xxrand.Intn(amount))
+	measure("query", key, func() {
+		xxrand.Intn(amount)
+		fmt.Println(cache.Get(key))
+	}, 100000)
 }
 
 func measure(action, name string, fn func(), iterations int) {

--- a/examples/million/main.go
+++ b/examples/million/main.go
@@ -140,7 +140,7 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 
 		out.Query(func(txn *column.Txn) error {
 			for _, p := range data {
-				txn.Insert(p)
+				txn.InsertObject(p)
 			}
 			return nil
 		})

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Perform a bulk insert
 	players.Query(func(txn *column.Txn) error {
 		for _, v := range loaded {
-			txn.Insert(v)
+			txn.InsertObject(v)
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR adds a new `Key` column type which is essentially a `string` column with a `map[string]uint32` currently. This allows for `O(1)` lookups by key in case where the row offset is not known. This adds an extra map lookup of course.

* Added `UpdateAtKey()` method to both transaction and collection. This allows to update or insert (upsert) an element at a specified key.
* Added `SelectAtKey()` method to both transaction and collection. This allows to read a row by its key.
* Renamed `Insert()` to `InsertObject()` and changed the signature of the existing insert methods.
* Added `Insert()` and `InsertWithTTL()` methods that take `func(column.Cursor) error` instead of a `map[string]interface{}` to keep the API consistent and not require a map when not needed.
* Fixed some buffer types