### PR TITLE
Chunked snapshot writer/reader

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -379,8 +379,17 @@ func (c *columns) Count() int {
 	return len(cols)
 }
 
-// Range iterates over columns in the registry.
-func (c *columns) Range(fn func(column *column) error) error {
+// Range iterates over columns in the registry. This is faster than RangeUntil
+// method.
+func (c *columns) Range(fn func(column *column)) {
+	cols := c.cols.Load().([]columnEntry)
+	for _, v := range cols {
+		fn(v.cols[0])
+	}
+}
+
+// RangeUntil iterates over columns in the registry until an error occurs.
+func (c *columns) RangeUntil(fn func(column *column) error) error {
 	cols := c.cols.Load().([]columnEntry)
 	for _, v := range cols {
 		if err := fn(v.cols[0]); err != nil {

--- a/collection_test.go
+++ b/collection_test.go
@@ -18,15 +18,15 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkCollection/insert-8         	    2608	    519498 ns/op	   24298 B/op	     500 allocs/op
-BenchmarkCollection/select-at-8      	42467803	        27.63 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/scan-8           	    1976	    574104 ns/op	      88 B/op	       0 allocs/op
-BenchmarkCollection/count-8          	  783828	      1516 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/range-8          	   17836	     67879 ns/op	       6 B/op	       0 allocs/op
-BenchmarkCollection/update-at-8      	 3707148	       322.9 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/update-all-8     	    1183	    976786 ns/op	    4025 B/op	       0 allocs/op
-BenchmarkCollection/delete-at-8      	 9005782	       130.1 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/delete-all-8     	 2359329	       493.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/insert-8                2174            534746 ns/op           25090 B/op        500 allocs/op
+BenchmarkCollection/select-at-8         42206409                28.19 ns/op            0 B/op          0 allocs/op
+BenchmarkCollection/scan-8                  2116            581193 ns/op            1872 B/op          0 allocs/op
+BenchmarkCollection/count-8               748689              1565 ns/op               5 B/op          0 allocs/op
+BenchmarkCollection/range-8                16476             73244 ns/op             216 B/op          0 allocs/op
+BenchmarkCollection/update-at-8          3717255               316.6 ns/op             1 B/op          0 allocs/op
+BenchmarkCollection/update-all-8            1176           1005992 ns/op            7134 B/op          1 allocs/op
+BenchmarkCollection/delete-at-8          8403426               145.0 ns/op             0 B/op          0 allocs/op
+BenchmarkCollection/delete-all-8         2338410               500.0 ns/op             1 B/op          0 allocs/op
 */
 func BenchmarkCollection(b *testing.B) {
 	b.Run("insert", func(b *testing.B) {

--- a/column.go
+++ b/column.go
@@ -43,7 +43,7 @@ type Column interface {
 	Value(idx uint32) (interface{}, bool)
 	Contains(idx uint32) bool
 	Index() *bitmap.Bitmap
-	Snapshot(*commit.Buffer)
+	Snapshot(chunk commit.Chunk, dst *commit.Buffer)
 }
 
 // Numeric represents a column that stores numbers.
@@ -249,8 +249,8 @@ func (c *columnBool) Index() *bitmap.Bitmap {
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnBool) Snapshot(dst *commit.Buffer) {
-	dst.PutBitmap(commit.PutTrue, c.data)
+func (c *columnBool) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	dst.PutBitmap(commit.PutTrue, chunk, c.data)
 }
 
 // --------------------------- funcs ----------------------------

--- a/column_generate.go
+++ b/column_generate.go
@@ -138,8 +138,8 @@ func (c *columnNumber) FilterUint64(offset uint32, index bitmap.Bitmap, predicat
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnNumber) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnNumber) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutNumber(commit.Put, idx, c.data[idx])
 	})
 }

--- a/column_index.go
+++ b/column_index.go
@@ -109,10 +109,8 @@ func (c *columnIndex) Index() *bitmap.Bitmap {
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnIndex) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
-		dst.PutOperation(commit.PutTrue, idx)
-	})
+func (c *columnIndex) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	dst.PutBitmap(commit.PutTrue, chunk, c.fill)
 }
 
 // --------------------------- Key ----------------------------

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -135,8 +135,8 @@ func (c *columnfloat32) FilterUint64(offset uint32, index bitmap.Bitmap, predica
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnfloat32) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnfloat32) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutFloat32(commit.Put, idx, c.data[idx])
 	})
 }
@@ -294,8 +294,8 @@ func (c *columnfloat64) FilterUint64(offset uint32, index bitmap.Bitmap, predica
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnfloat64) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnfloat64) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutFloat64(commit.Put, idx, c.data[idx])
 	})
 }
@@ -453,8 +453,8 @@ func (c *columnint) FilterUint64(offset uint32, index bitmap.Bitmap, predicate f
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnint) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnint) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutInt(commit.Put, idx, c.data[idx])
 	})
 }
@@ -612,8 +612,8 @@ func (c *columnint16) FilterUint64(offset uint32, index bitmap.Bitmap, predicate
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnint16) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnint16) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutInt16(commit.Put, idx, c.data[idx])
 	})
 }
@@ -771,8 +771,8 @@ func (c *columnint32) FilterUint64(offset uint32, index bitmap.Bitmap, predicate
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnint32) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnint32) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutInt32(commit.Put, idx, c.data[idx])
 	})
 }
@@ -930,8 +930,8 @@ func (c *columnint64) FilterUint64(offset uint32, index bitmap.Bitmap, predicate
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnint64) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnint64) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutInt64(commit.Put, idx, c.data[idx])
 	})
 }
@@ -1089,8 +1089,8 @@ func (c *columnuint) FilterUint64(offset uint32, index bitmap.Bitmap, predicate 
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnuint) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnuint) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutUint(commit.Put, idx, c.data[idx])
 	})
 }
@@ -1248,8 +1248,8 @@ func (c *columnuint16) FilterUint64(offset uint32, index bitmap.Bitmap, predicat
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnuint16) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnuint16) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutUint16(commit.Put, idx, c.data[idx])
 	})
 }
@@ -1407,8 +1407,8 @@ func (c *columnuint32) FilterUint64(offset uint32, index bitmap.Bitmap, predicat
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnuint32) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnuint32) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutUint32(commit.Put, idx, c.data[idx])
 	})
 }
@@ -1566,8 +1566,8 @@ func (c *columnuint64) FilterUint64(offset uint32, index bitmap.Bitmap, predicat
 }
 
 // Snapshot writes the entire column into the specified destination buffer
-func (c *columnuint64) Snapshot(dst *commit.Buffer) {
-	c.fill.Range(func(idx uint32) {
+func (c *columnuint64) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	chunk.Range(c.fill, func(idx uint32) {
 		dst.PutUint64(commit.Put, idx, c.data[idx])
 	})
 }

--- a/column_test.go
+++ b/column_test.go
@@ -194,7 +194,7 @@ func testPutDelete(t *testing.T, column Column, value interface{}) {
 // testSnapshot test a snapshot of a column
 func testSnapshot(t *testing.T, column Column, value interface{}) {
 	buf := commit.NewBuffer(8)
-	column.Snapshot(buf)
+	column.Snapshot(0, buf)
 	assert.False(t, buf.IsEmpty())
 }
 
@@ -383,7 +383,7 @@ func TestSnapshotBool(t *testing.T) {
 
 	// Snapshot into a new buffer
 	buf := commit.NewBuffer(8)
-	input.Snapshot(buf)
+	input.Snapshot(0, buf)
 
 	// Create a new reader and read the column
 	rdr := commit.NewReader()
@@ -407,7 +407,7 @@ func TestSnapshotIndex(t *testing.T) {
 
 	// Snapshot into a new buffer
 	buf := commit.NewBuffer(8)
-	input.Snapshot(buf)
+	input.Snapshot(0, buf)
 
 	// Create a new reader and read the column
 	rdr := commit.NewReader()

--- a/column_test.go
+++ b/column_test.go
@@ -13,25 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-/*
-cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkColumn/chunkOf-8         	 8466814	       136.2 ns/op	       0 B/op	       0 allocs/op
-*/
-func BenchmarkColumn(b *testing.B) {
-	b.Run("chunkOf", func(b *testing.B) {
-		var temp bitmap.Bitmap
-		temp.Grow(2 * chunkSize)
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		for n := 0; n < b.N; n++ {
-			for i := 0; i < 100; i++ {
-				chunkOf(temp, 1)
-			}
-		}
-	})
-}
-
 func TestColumns(t *testing.T) {
 	tests := []struct {
 		column Column

--- a/commit/buffer_codec.go
+++ b/commit/buffer_codec.go
@@ -42,7 +42,7 @@ func writeChunksTo(w *iostream.Writer, chunks []header) error {
 
 	var temp [12]byte
 	for _, v := range chunks {
-		binary.BigEndian.PutUint32(temp[0:4], v.Chunk)
+		binary.BigEndian.PutUint32(temp[0:4], uint32(v.Chunk))
 		binary.BigEndian.PutUint32(temp[4:8], v.Start)
 		binary.BigEndian.PutUint32(temp[8:12], v.Value)
 		if _, err := w.Write(temp[:]); err != nil {
@@ -97,7 +97,7 @@ func readChunksFrom(r *iostream.Reader) ([]header, error) {
 			return nil, err
 		}
 
-		v[i].Chunk = binary.BigEndian.Uint32(temp[0:4])
+		v[i].Chunk = Chunk(binary.BigEndian.Uint32(temp[0:4]))
 		v[i].Start = binary.BigEndian.Uint32(temp[4:8])
 		v[i].Value = binary.BigEndian.Uint32(temp[8:12])
 	}

--- a/commit/buffer_test.go
+++ b/commit/buffer_test.go
@@ -240,7 +240,7 @@ func TestPutNil(t *testing.T) {
 
 func TestPutBitmap(t *testing.T) {
 	buf := NewBuffer(0)
-	buf.PutBitmap(Insert, bitmap.Bitmap{0xff})
+	buf.PutBitmap(Insert, 0, bitmap.Bitmap{0xff})
 
 	r := NewReader()
 	r.Seek(buf)

--- a/commit/commit.go
+++ b/commit/commit.go
@@ -3,17 +3,63 @@
 
 package commit
 
+import "github.com/kelindar/bitmap"
+
+// --------------------------- Chunk ----------------------------
+
+const (
+	bitmapShift = chunkShift - 6
+	bitmapSize  = 1 << bitmapShift
+	chunkShift  = 14 // 16K
+	chunkSize   = 1 << chunkShift
+)
+
+// Chunk represents a chunk number
+type Chunk uint32
+
+// ChunkAt returns the chunk number at a given index
+func ChunkAt(index uint32) Chunk {
+	return Chunk(index) / chunkSize
+}
+
+// OfBitmap computes a chunk for a given bitmap
+func (c Chunk) OfBitmap(v bitmap.Bitmap) bitmap.Bitmap {
+	const shift = chunkShift - 6
+	x1 := min(int32(c+1)<<shift, int32(len(v)))
+	x0 := min(int32(c)<<shift, x1)
+	return v[x0:x1]
+}
+
+// Offset returns the offset at which the chunk should be positioned
+func (c Chunk) Offset() uint32 {
+	return uint32(int32(c) << chunkShift)
+}
+
+// Range iterates over a chunk given a bitmap
+func (c Chunk) Range(v bitmap.Bitmap, fn func(idx uint32)) {
+	offset := c.Offset()
+	output := c.OfBitmap(v)
+	output.Range(func(idx uint32) {
+		fn(offset + idx)
+	})
+}
+
+// min returns a minimum of two numbers without branches.
+func min(v1, v2 int32) int32 {
+	return v2 + ((v1 - v2) & ((v1 - v2) >> 31))
+}
+
+// --------------------------- Commit ----------------------------
+
 // Writer represents a contract that a commit writer must implement
 type Writer interface {
 	Write(commit Commit) error
 }
 
-// --------------------------- Commit ----------------------------
-
 // Commit represents an individual transaction commit. If multiple chunks are committed
 // in the same transaction, it would result in multiple commits per transaction.
 type Commit struct {
-	Chunk   uint32    // The chunk number
+	Chunk   Chunk     // The chunk number
 	Updates []*Buffer // The update buffers
 }
 

--- a/commit/commit.go
+++ b/commit/commit.go
@@ -19,7 +19,7 @@ type Chunk uint32
 
 // ChunkAt returns the chunk number at a given index
 func ChunkAt(index uint32) Chunk {
-	return Chunk(index) / chunkSize
+	return Chunk(index >> chunkShift)
 }
 
 // OfBitmap computes a chunk for a given bitmap
@@ -30,14 +30,19 @@ func (c Chunk) OfBitmap(v bitmap.Bitmap) bitmap.Bitmap {
 	return v[x0:x1]
 }
 
-// Offset returns the offset at which the chunk should be positioned
-func (c Chunk) Offset() uint32 {
+// Min returns the min offset at which the chunk should be starting
+func (c Chunk) Min() uint32 {
 	return uint32(int32(c) << chunkShift)
+}
+
+// Max returns the max offset at which the chunk should be ending
+func (c Chunk) Max() uint32 {
+	return c.Min() + chunkSize - 1
 }
 
 // Range iterates over a chunk given a bitmap
 func (c Chunk) Range(v bitmap.Bitmap, fn func(idx uint32)) {
-	offset := c.Offset()
+	offset := c.Min()
 	output := c.OfBitmap(v)
 	output.Range(func(idx uint32) {
 		fn(offset + idx)

--- a/commit/commit_test.go
+++ b/commit/commit_test.go
@@ -35,6 +35,37 @@ func TestWriterChannel(t *testing.T) {
 	assert.Equal(t, 123, int(out.Chunk))
 }
 
+func TestChunkOffset(t *testing.T) {
+	tests := []struct {
+		chunk  Chunk
+		offset uint32
+	}{
+		{chunk: 0, offset: 0},
+		{chunk: 1, offset: chunkSize},
+		{chunk: 2, offset: 2 * chunkSize},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.offset, tc.chunk.Offset())
+	}
+}
+
+func TestChunkAt(t *testing.T) {
+	tests := []struct {
+		index uint32
+		chunk Chunk
+	}{
+		{index: 0, chunk: 0},
+		{index: chunkSize - 1, chunk: 0},
+		{index: chunkSize, chunk: 1},
+		{index: chunkSize + 1, chunk: 1},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.chunk, ChunkAt(tc.index))
+	}
+}
+
 type limitWriter struct {
 	value uint32
 	Limit int

--- a/commit/reader.go
+++ b/commit/reader.go
@@ -198,7 +198,7 @@ func (r *Reader) SwapBool(b bool) {
 // --------------------------- Chunk Iterator ----------------------------
 
 // Range iterates over parts of the buffer which match the specified chunk.
-func (r *Reader) Range(buf *Buffer, chunk uint32, fn func(*Reader)) {
+func (r *Reader) Range(buf *Buffer, chunk Chunk, fn func(*Reader)) {
 	for i, c := range buf.chunks {
 		if c.Chunk != chunk {
 			continue // Not the right chunk, skip it
@@ -221,7 +221,7 @@ func (r *Reader) Range(buf *Buffer, chunk uint32, fn func(*Reader)) {
 }
 
 // MaxOffset returns the maximum offset for a chunk
-func (r *Reader) MaxOffset(buf *Buffer, chunk uint32) (max uint32) {
+func (r *Reader) MaxOffset(buf *Buffer, chunk Chunk) (max uint32) {
 	if buf == nil {
 		return
 	}

--- a/commit/reader_test.go
+++ b/commit/reader_test.go
@@ -65,7 +65,7 @@ func TestRange(t *testing.T) {
 
 	r := NewReader()
 	for i := 0; i < 100; i++ {
-		r.Range(buf, uint32(i), func(r *Reader) {
+		r.Range(buf, Chunk(i), func(r *Reader) {
 			for r.Next() {
 				assert.Equal(t, Put, r.Type)
 				assert.Equal(t, i, int(r.Offset>>chunkShift))
@@ -96,8 +96,8 @@ func TestReadSwap(t *testing.T) {
 	// Should only have 1 chunk
 	assert.False(t, buf.IsEmpty())
 	assert.Equal(t, 1, len(buf.chunks))
-	buf.RangeChunks(func(chunk uint32) {
-		assert.Equal(t, uint32(0), chunk)
+	buf.RangeChunks(func(chunk Chunk) {
+		assert.Equal(t, Chunk(0), chunk)
 	})
 
 	r := NewReader()

--- a/snapshot.go
+++ b/snapshot.go
@@ -83,7 +83,7 @@ func (c *Collection) WriteTo(dst io.Writer) (int64, error) {
 			}
 
 			// Snapshot each column and write the buffer
-			return c.cols.Range(func(column *column) error {
+			return c.cols.RangeUntil(func(column *column) error {
 				buffer.Reset(column.name)
 				column.Snapshot(chunk, buffer)
 				return writer.WriteSelf(buffer)

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -22,8 +22,8 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkSave/write-to-8         	      12	  87761500 ns/op	1193.94 MB/s	41037068 B/op	     679 allocs/op
-BenchmarkSave/read-from-8        	      13	  85118831 ns/op	1231.01 MB/s	105711508 B/op	      91 allocs/op
+BenchmarkSave/write-to-8         	       8	 131800350 ns/op	 981.98 MB/s	 6539521 B/op	    1950 allocs/op
+BenchmarkSave/read-from-8        	      13	  79411685 ns/op	1629.80 MB/s	135661336 B/op	    4610 allocs/op
 */
 func BenchmarkSave(b *testing.B) {
 	b.Run("write-to", func(b *testing.B) {
@@ -175,7 +175,7 @@ func runReplication(t *testing.T, updates, inserts, concurrency int) {
 func TestSnapshot(t *testing.T) {
 	input := NewCollection()
 	input.CreateColumn("name", ForEnum())
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2e4; i++ {
 		input.Insert("name", func(v Cursor) error {
 			v.Set("Roman")
 			return nil
@@ -188,6 +188,7 @@ func TestSnapshot(t *testing.T) {
 	assert.NotZero(t, n)
 	assert.NoError(t, err)
 
+	println("----")
 	// Restore the collection from the snapshot
 	output := NewCollection()
 	output.CreateColumn("name", ForEnum())
@@ -206,7 +207,7 @@ func TestSnapshotSize(t *testing.T) {
 	output := bytes.NewBuffer(nil)
 	_, err := input.WriteTo(output)
 	assert.NoError(t, err)
-	assert.Equal(t, 107030, output.Len())
+	assert.Equal(t, 107037, output.Len())
 }
 
 func TestWriteToFailures(t *testing.T) {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -188,7 +188,6 @@ func TestSnapshot(t *testing.T) {
 	assert.NotZero(t, n)
 	assert.NoError(t, err)
 
-	println("----")
 	// Restore the collection from the snapshot
 	output := NewCollection()
 	output.CreateColumn("name", ForEnum())

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -206,7 +206,7 @@ func TestSnapshotSize(t *testing.T) {
 	output := bytes.NewBuffer(nil)
 	_, err := input.WriteTo(output)
 	assert.NoError(t, err)
-	assert.Equal(t, 110097, output.Len())
+	assert.Equal(t, 107030, output.Len())
 }
 
 func TestWriteToFailures(t *testing.T) {

--- a/txn.go
+++ b/txn.go
@@ -132,7 +132,7 @@ func (txn *Txn) columnAt(columnName string) (*column, bool) {
 func (txn *Txn) With(columns ...string) *Txn {
 	for _, columnName := range columns {
 		if idx, ok := txn.columnAt(columnName); ok {
-			txn.rangeReadPair(*idx.Column.Index(), func(dst, src bitmap.Bitmap) {
+			txn.rangeReadPair(idx, func(dst, src bitmap.Bitmap) {
 				dst.And(src)
 			})
 		} else {
@@ -146,7 +146,7 @@ func (txn *Txn) With(columns ...string) *Txn {
 func (txn *Txn) Without(columns ...string) *Txn {
 	for _, columnName := range columns {
 		if idx, ok := txn.columnAt(columnName); ok {
-			txn.rangeReadPair(*idx.Column.Index(), func(dst, src bitmap.Bitmap) {
+			txn.rangeReadPair(idx, func(dst, src bitmap.Bitmap) {
 				dst.AndNot(src)
 			})
 		}
@@ -158,7 +158,7 @@ func (txn *Txn) Without(columns ...string) *Txn {
 func (txn *Txn) Union(columns ...string) *Txn {
 	for _, columnName := range columns {
 		if idx, ok := txn.columnAt(columnName); ok {
-			txn.rangeReadPair(*idx.Column.Index(), func(dst, src bitmap.Bitmap) {
+			txn.rangeReadPair(idx, func(dst, src bitmap.Bitmap) {
 				dst.Or(src)
 			})
 		}

--- a/txn.go
+++ b/txn.go
@@ -433,13 +433,12 @@ func (txn *Txn) commit() {
 
 	// Grow the size of the fill list
 	markers, changedRows := txn.findMarkers()
-	max := txn.reader.MaxOffset(markers, commit.Chunk(lastChunk))
-	if max > 0 {
+	if max := txn.reader.MaxOffset(markers, commit.Chunk(lastChunk)); max > 0 {
 		txn.commitCapacity(max)
 	}
 
 	// Commit chunk by chunk to reduce lock contentions
-	txn.rangeWrite(func(chunk commit.Chunk, fill bitmap.Bitmap) {
+	txn.rangeWrite(func(chunk commit.Chunk, fill bitmap.Bitmap) error {
 		if changedRows {
 			txn.commitMarkers(chunk, fill, markers)
 		}
@@ -453,6 +452,7 @@ func (txn *Txn) commit() {
 				Updates: txn.updates,
 			})
 		}
+		return nil
 	})
 }
 

--- a/txn.go
+++ b/txn.go
@@ -501,9 +501,8 @@ func (txn *Txn) commitMarkers(chunk commit.Chunk, fill bitmap.Bitmap, buffer *co
 	// We also need to apply the delete operations on the column so it
 	// can remove unnecessary data.
 	txn.reader.Range(buffer, chunk, func(r *commit.Reader) {
-		txn.owner.cols.Range(func(column *column) error {
+		txn.owner.cols.Range(func(column *column) {
 			column.Apply(r)
-			return nil
 		})
 	})
 
@@ -529,8 +528,7 @@ func (txn *Txn) commitCapacity(max uint32) {
 
 	// Grow the fill list and all of the owner's columns
 	txn.owner.fill.Grow(max)
-	txn.owner.cols.Range(func(column *column) error {
+	txn.owner.cols.Range(func(column *column) {
 		column.Grow(max)
-		return nil
 	})
 }

--- a/txn_lock.go
+++ b/txn_lock.go
@@ -5,6 +5,7 @@ package column
 
 import (
 	"github.com/kelindar/bitmap"
+	"github.com/kelindar/column/commit"
 )
 
 const (
@@ -20,6 +21,13 @@ func chunkOf(v bitmap.Bitmap, chunk uint32) bitmap.Bitmap {
 	x1 := min(int32(chunk+1)<<shift, int32(len(v)))
 	x0 := min(int32(chunk)<<shift, x1)
 	return v[x0:x1]
+}
+
+// chunkBounds resolves a chunk window bounds
+func chunkBounds(chunk, maxSize uint32) (uint32, uint32) {
+	x1 := min(int32(chunk+1)<<chunkShift, int32(maxSize))
+	x0 := min(int32(chunk)<<chunkShift, x1)
+	return uint32(x0), uint32(x1)
 }
 
 // min returns a minimum of two numbers without branches.
@@ -57,18 +65,24 @@ func (txn *Txn) rangeReadPair(other bitmap.Bitmap, f func(a, b bitmap.Bitmap)) {
 
 // rangeWrite ranges over the dirty chunks and acquires exclusive latches along
 // the way. This is used to commit a transaction.
-func (txn *Txn) rangeWrite(f func(chunk uint32, fill bitmap.Bitmap)) {
-	lock := txn.owner.slock
+func (txn *Txn) rangeWrite(fn func(chunk commit.Chunk, fill bitmap.Bitmap)) {
 	txn.dirty.Range(func(chunk uint32) {
-		lock.Lock(uint(chunk))
-
-		// Compute the fill
-		txn.owner.lock.Lock()
-		fill := chunkOf(txn.owner.fill, chunk)
-		txn.owner.lock.Unlock()
-
-		// Call the delegate
-		f(chunk, fill)
-		lock.Unlock(uint(chunk))
+		txn.owner.writeAtChunk(commit.Chunk(chunk), fn)
 	})
+}
+
+// writeAtChunk acquires appropriate locks for a chunk and executes a
+// write callback
+func (c *Collection) writeAtChunk(chunk commit.Chunk, fn func(chunk commit.Chunk, fill bitmap.Bitmap)) {
+	lock := c.slock
+	lock.Lock(uint(chunk))
+
+	// Compute the fill
+	c.lock.Lock()
+	fill := chunk.OfBitmap(c.fill)
+	c.lock.Unlock()
+
+	// Call the delegate
+	fn(chunk, fill)
+	lock.Unlock(uint(chunk))
 }

--- a/txn_lock.go
+++ b/txn_lock.go
@@ -15,37 +15,17 @@ const (
 	chunkSize   = 1 << chunkShift
 )
 
-// chunkOf returns a part of a bitmap for the corresponding chunk
-func chunkOf(v bitmap.Bitmap, chunk uint32) bitmap.Bitmap {
-	const shift = chunkShift - 6
-	x1 := min(int32(chunk+1)<<shift, int32(len(v)))
-	x0 := min(int32(chunk)<<shift, x1)
-	return v[x0:x1]
-}
-
-// chunkBounds resolves a chunk window bounds
-func chunkBounds(chunk, maxSize uint32) (uint32, uint32) {
-	x1 := min(int32(chunk+1)<<chunkShift, int32(maxSize))
-	x0 := min(int32(chunk)<<chunkShift, x1)
-	return uint32(x0), uint32(x1)
-}
-
-// min returns a minimum of two numbers without branches.
-func min(v1, v2 int32) int32 {
-	return v2 + ((v1 - v2) & ((v1 - v2) >> 31))
-}
-
 // --------------------------- Locked Range ---------------------------
 
 // rangeRead iterates over index, chunk by chunk and ensures that each
 // chunk is protected by an appropriate read lock.
 func (txn *Txn) rangeRead(f func(offset uint32, index bitmap.Bitmap)) {
-	limit := uint32(len(txn.index) >> bitmapShift)
+	limit := commit.Chunk(len(txn.index) >> bitmapShift)
 	lock := txn.owner.slock
 
-	for chunk := uint32(0); chunk <= limit; chunk++ {
+	for chunk := commit.Chunk(0); chunk <= limit; chunk++ {
 		lock.RLock(uint(chunk))
-		f(chunk<<chunkShift, chunkOf(txn.index, chunk))
+		f(chunk.Min(), chunk.OfBitmap(txn.index))
 		lock.RUnlock(uint(chunk))
 	}
 }
@@ -53,19 +33,19 @@ func (txn *Txn) rangeRead(f func(offset uint32, index bitmap.Bitmap)) {
 // rangeReadPair iterates over the index and another bitmap, chunk by chunk and
 // ensures that each chunk is protected by an appropriate read lock.
 func (txn *Txn) rangeReadPair(other bitmap.Bitmap, f func(a, b bitmap.Bitmap)) {
-	limit := uint32(len(txn.index) >> bitmapShift)
+	limit := commit.Chunk(len(txn.index) >> bitmapShift)
 	lock := txn.owner.slock
 
-	for chunk := uint32(0); chunk <= limit; chunk++ {
+	for chunk := commit.Chunk(0); chunk <= limit; chunk++ {
 		lock.RLock(uint(chunk))
-		f(chunkOf(txn.index, chunk), chunkOf(other, chunk))
+		f(chunk.OfBitmap(txn.index), chunk.OfBitmap(other))
 		lock.RUnlock(uint(chunk))
 	}
 }
 
 // rangeWrite ranges over the dirty chunks and acquires exclusive latches along
 // the way. This is used to commit a transaction.
-func (txn *Txn) rangeWrite(fn func(chunk commit.Chunk, fill bitmap.Bitmap)) {
+func (txn *Txn) rangeWrite(fn func(chunk commit.Chunk, fill bitmap.Bitmap) error) {
 	txn.dirty.Range(func(chunk uint32) {
 		txn.owner.writeAtChunk(commit.Chunk(chunk), fn)
 	})
@@ -73,7 +53,7 @@ func (txn *Txn) rangeWrite(fn func(chunk commit.Chunk, fill bitmap.Bitmap)) {
 
 // writeAtChunk acquires appropriate locks for a chunk and executes a
 // write callback
-func (c *Collection) writeAtChunk(chunk commit.Chunk, fn func(chunk commit.Chunk, fill bitmap.Bitmap)) {
+func (c *Collection) writeAtChunk(chunk commit.Chunk, fn func(chunk commit.Chunk, fill bitmap.Bitmap) error) (err error) {
 	lock := c.slock
 	lock.Lock(uint(chunk))
 
@@ -83,6 +63,7 @@ func (c *Collection) writeAtChunk(chunk commit.Chunk, fn func(chunk commit.Chunk
 	c.lock.Unlock()
 
 	// Call the delegate
-	fn(chunk, fill)
+	err = fn(chunk, fill)
 	lock.Unlock(uint(chunk))
+	return
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kelindar/bitmap"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -358,53 +357,6 @@ func TestUpdateWithRollback(t *testing.T) {
 		assert.Equal(t, 500, txn.With("rich").Count())
 		return nil
 	})
-}
-
-func TestChunkOf(t *testing.T) {
-	tests := []struct {
-		size   uint32
-		chunk  uint32
-		expect int
-	}{
-		{size: 3 * chunkSize, expect: chunkSize, chunk: 0},
-		{size: 3 * chunkSize, expect: chunkSize, chunk: 1},
-		{size: 3 * chunkSize, expect: chunkSize, chunk: 2},
-		{size: 3 * chunkSize, expect: 0, chunk: 3},
-		{size: 2*chunkSize - 70, expect: chunkSize, chunk: 0},
-		{size: 2*chunkSize - 70, expect: 16320, chunk: 1},
-		{size: 2*chunkSize - 70, expect: 0, chunk: 2},
-		{size: 2*chunkSize - 10, expect: chunkSize, chunk: 0},
-		{size: 2*chunkSize - 10, expect: chunkSize, chunk: 1},
-		{size: 2*chunkSize - 10, expect: 0, chunk: 2},
-	}
-
-	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%v-%v", tc.chunk, tc.size), func(t *testing.T) {
-			var tmp bitmap.Bitmap
-			tmp.Grow(tc.size - 1)
-			assert.Equal(t, tc.expect, len(chunkOf(tmp, tc.chunk))*64)
-		})
-	}
-}
-
-func TestMin(t *testing.T) {
-	tests := []struct {
-		v1, v2 int32
-		expect int32
-	}{
-		{v1: 0, v2: 0, expect: 0},
-		{v1: 10, v2: 0, expect: 0},
-		{v1: 0, v2: 10, expect: 0},
-		{v1: 10, v2: 20, expect: 10},
-		{v1: 20, v2: 10, expect: 10},
-		{v1: 20, v2: 20, expect: 20},
-	}
-
-	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%v,%v", tc.v1, tc.v2), func(t *testing.T) {
-			assert.Equal(t, int(tc.expect), int(min(tc.v1, tc.v2)))
-		})
-	}
 }
 
 // Details: https://github.com/kelindar/column/issues/17


### PR DESCRIPTION
This PR is a second work package required in order to properly implement snapshotting properly. This changes the way snapshots are being written and read, which can now be done chunk by chunk, allowing for simultaneous write transactions to go through. 

Once this is merged, next step would be to implement a redo log and write into the commit all of the changed chunks that are happening during the snapshot process itself, allowing us to restore a consistent state of the database on loading.