### PR TITLE
Smoother column resize

### DIFF
--- a/column.go
+++ b/column.go
@@ -261,14 +261,25 @@ func (c *columnBool) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 
 // --------------------------- funcs ----------------------------
 
-// capacityFor computes the next power of 2 for a given index
-func capacityFor(v uint32) int {
-	v--
-	v |= v >> 1
-	v |= v >> 2
-	v |= v >> 4
-	v |= v >> 8
-	v |= v >> 16
-	v++
-	return int(v)
+// resize calculates the new required capacity and a new index
+func resize(capacity int, v uint32) int {
+	const threshold = 256
+	if v < threshold {
+		v |= v >> 1
+		v |= v >> 2
+		v |= v >> 4
+		v |= v >> 8
+		v |= v >> 16
+		v++
+		return int(v)
+	}
+
+	if capacity < threshold {
+		capacity = threshold
+	}
+
+	for 0 < capacity && capacity < int(v+1) {
+		capacity += (capacity + 3*threshold) / 4
+	}
+	return capacity
 }

--- a/column_generate.go
+++ b/column_generate.go
@@ -40,7 +40,7 @@ func (c *columnNumber) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]number, idx+1, capacityFor(idx+1))
+	clone := make([]number, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -37,7 +37,7 @@ func (c *columnfloat32) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]float32, idx+1, capacityFor(idx+1))
+	clone := make([]float32, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -196,7 +196,7 @@ func (c *columnfloat64) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]float64, idx+1, capacityFor(idx+1))
+	clone := make([]float64, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -355,7 +355,7 @@ func (c *columnint) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]int, idx+1, capacityFor(idx+1))
+	clone := make([]int, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -514,7 +514,7 @@ func (c *columnint16) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]int16, idx+1, capacityFor(idx+1))
+	clone := make([]int16, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -673,7 +673,7 @@ func (c *columnint32) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]int32, idx+1, capacityFor(idx+1))
+	clone := make([]int32, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -832,7 +832,7 @@ func (c *columnint64) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]int64, idx+1, capacityFor(idx+1))
+	clone := make([]int64, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -991,7 +991,7 @@ func (c *columnuint) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]uint, idx+1, capacityFor(idx+1))
+	clone := make([]uint, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -1150,7 +1150,7 @@ func (c *columnuint16) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]uint16, idx+1, capacityFor(idx+1))
+	clone := make([]uint16, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -1309,7 +1309,7 @@ func (c *columnuint32) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]uint32, idx+1, capacityFor(idx+1))
+	clone := make([]uint32, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }
@@ -1468,7 +1468,7 @@ func (c *columnuint64) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]uint64, idx+1, capacityFor(idx+1))
+	clone := make([]uint64, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }

--- a/column_strings.go
+++ b/column_strings.go
@@ -47,7 +47,7 @@ func (c *columnEnum) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]uint32, idx+1, capacityFor(idx+1))
+	clone := make([]uint32, idx+1, resize(cap(c.locs), idx+1))
 	copy(clone, c.locs)
 	c.locs = clone
 }
@@ -175,7 +175,7 @@ func (c *columnString) Grow(idx uint32) {
 	}
 
 	c.fill.Grow(idx)
-	clone := make([]string, idx+1, capacityFor(idx+1))
+	clone := make([]string, idx+1, resize(cap(c.data), idx+1))
 	copy(clone, c.data)
 	c.data = clone
 }

--- a/column_test.go
+++ b/column_test.go
@@ -398,3 +398,17 @@ func TestSnapshotIndex(t *testing.T) {
 	output.Apply(rdr)
 	assert.Equal(t, input.Column.(*columnIndex).fill, output.Column.(*columnIndex).fill)
 }
+
+func TestResize(t *testing.T) {
+	assert.Equal(t, 1, resize(100, 0))
+	assert.Equal(t, 2, resize(100, 1))
+	assert.Equal(t, 4, resize(100, 2))
+	assert.Equal(t, 16, resize(100, 11))
+	assert.Equal(t, 256, resize(100, 255))
+	assert.Equal(t, 1232, resize(100, 1000))
+	assert.Equal(t, 1232, resize(200, 1000))
+	assert.Equal(t, 1232, resize(512, 1000))
+	assert.Equal(t, 1213, resize(500, 1000)) // Inconsistent
+	assert.Equal(t, 22504, resize(512, 20000))
+	assert.Equal(t, 28322, resize(22504, 22600))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kelindar/column
 go 1.17
 
 require (
-	github.com/kelindar/bitmap v1.1.4
+	github.com/kelindar/bitmap v1.1.5
 	github.com/kelindar/intmap v1.1.0
 	github.com/kelindar/iostream v1.3.0
 	github.com/kelindar/smutex v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/kelindar/async v1.0.0 h1:oJiFAt3fVB/b5zVZKPBU+pP9lR3JVyeox9pYlpdnIK8=
 github.com/kelindar/async v1.0.0/go.mod h1:bJRlwaRiqdHi+4dpVDNHdwgyRyk6TxpA21fByLf7hIY=
-github.com/kelindar/bitmap v1.1.4 h1:rNwZ6RMRhrE3Um0QqBwFoJAcAzYi/4M7XGDCZYS6TOU=
-github.com/kelindar/bitmap v1.1.4/go.mod h1:shAFyS8BOif+pvJ05GqxnCM0SdohHQjKvDetqI/9z6M=
+github.com/kelindar/bitmap v1.1.5 h1:cqXplFOOwJX/HRu+GZBcz03wo2LZftVUMsuAjW/3/rQ=
+github.com/kelindar/bitmap v1.1.5/go.mod h1:URwjvM6WXldcKN7/D3FLHy0LSkEdg3rE7VjdN1DcI9E=
 github.com/kelindar/intmap v1.1.0 h1:S+YEDvw5FQus5UJDEG+xsLp8il3BTYqBMkkuVVZPMH8=
 github.com/kelindar/intmap v1.1.0/go.mod h1:tDanawPWq1B0HC+X3W8Z6IKNrJqxjruy6CdyTlf6Nic=
 github.com/kelindar/iostream v1.3.0 h1:Bz2qQabipZlF1XCk64bnxsGLete+iHtayGPeWVpbwbo=


### PR DESCRIPTION
This PR makes the capacity resize of columns and bitmaps smoother, using a similar function to Go slices, where after 256 elements the capacity increases by ~25%. This is useful for large size collections, where next power of two would potentially generate a lot of wasted memory.