### PR TITLE
Refactor snapshot

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -283,14 +283,19 @@ func (c *Collection) CreateIndex(indexName, columnName string, fn func(r Reader)
 	c.cols.Store(columnName, column, index)
 	c.lock.Unlock()
 
-	// If a column with this name already exists, iterate through all of the values
-	// that we have in the collection and apply the filter.
-	return c.Query(func(txn *Txn) error {
-		impl := index.Column.(*columnIndex)
-		return txn.With(columnName).Range(columnName, func(v Cursor) {
-			impl.Update(&v)
-		})
-	})
+	// Iterate over all of the values of the target column, chunk by chunk and fill
+	// the index accordingly.
+	chunks := c.chunks()
+	buffer := commit.NewBuffer(c.Count())
+	reader := commit.NewReader()
+	for chunk := commit.Chunk(0); int(chunk) < chunks; chunk++ {
+		if column.Snapshot(chunk, buffer) {
+			reader.Seek(buffer)
+			index.Apply(reader)
+		}
+	}
+
+	return nil
 }
 
 // DropIndex removes the index column with the specified name. If the index with this

--- a/collection.go
+++ b/collection.go
@@ -34,7 +34,6 @@ type Collection struct {
 	cols    columns            // The map of columns
 	fill    bitmap.Bitmap      // The fill-list
 	opts    Options            // The options configured
-	codec   codec              // The compression codec
 	logger  commit.Logger      // The commit logger for CDC
 	record  *commit.Log        // The commit logger for snapshot
 	pk      *columnKey         // The primary key column
@@ -79,7 +78,6 @@ func NewCollection(opts ...Options) *Collection {
 		slock:  new(smutex.SMutex128),
 		fill:   make(bitmap.Bitmap, 0, options.Capacity>>6),
 		logger: options.Writer,
-		codec:  newCodec(&options),
 		cancel: cancel,
 	}
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -170,7 +170,7 @@ func TestCollection(t *testing.T) {
 	// Should not drop, since it's not an index
 	col.DropIndex("name")
 
-	// Create a coupe of indices
+	// Create a couple of indexes
 	assert.Error(t, col.CreateIndex("", "", nil))
 	assert.NoError(t, col.CreateIndex("rich", "wallet", func(r Reader) bool {
 		return r.Float() > 100

--- a/column.go
+++ b/column.go
@@ -168,6 +168,17 @@ func (c *column) Apply(r *commit.Reader) {
 	c.Column.Apply(r)
 }
 
+// Snapshot takes a snapshot of a column, skipping indexes
+func (c *column) Snapshot(chunk commit.Chunk, buffer *commit.Buffer) bool {
+	if c.IsIndex() {
+		return false
+	}
+
+	buffer.Reset(c.name)
+	c.Column.Snapshot(chunk, buffer)
+	return true
+}
+
 // Value retrieves a value at a specified index
 func (c *column) Value(idx uint32) (v interface{}, ok bool) {
 	v, ok = c.Column.Value(idx)

--- a/column_index.go
+++ b/column_index.go
@@ -80,16 +80,6 @@ func (c *columnIndex) Apply(r *commit.Reader) {
 	}
 }
 
-// Update updates a single value in the index.
-func (c *columnIndex) Update(r Reader) {
-	if c.rule(r) {
-		c.fill.Set(r.Index())
-		return
-	}
-
-	c.fill.Remove(r.Index())
-}
-
 // Value retrieves a value at a specified index.
 func (c *columnIndex) Value(idx uint32) (v interface{}, ok bool) {
 	if idx < uint32(len(c.fill))<<6 {

--- a/column_test.go
+++ b/column_test.go
@@ -379,16 +379,17 @@ func TestSnapshotIndex(t *testing.T) {
 	predicateFn := func(Reader) bool {
 		return true
 	}
+
 	input := newIndex("test", "a", predicateFn)
 	input.Grow(8)
-	applyChanges(input,
+	applyChanges(input.Column,
 		Update{commit.Put, 2, true},
 		Update{commit.Put, 5, true},
 	)
 
 	// Snapshot into a new buffer
 	buf := commit.NewBuffer(8)
-	input.Snapshot(0, buf)
+	input.Column.Snapshot(0, buf)
 
 	// Create a new reader and read the column
 	rdr := commit.NewReader()

--- a/snapshot.go
+++ b/snapshot.go
@@ -41,7 +41,7 @@ func (c *Collection) Replay(change commit.Commit) error {
 // Restore restores the collection from the underlying snapshot reader. This operation
 // should be called before any of transactions, right after initialization.
 func (c *Collection) Restore(snapshot io.ReadWriter) error {
-	commits, err := c.readState(snapshot)
+	commits, err := c.readState(s2.NewReader(snapshot))
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func (c *Collection) Snapshot(dst io.Writer) error {
 
 	// Take a snapshot of the current state
 	defer os.Remove(recorder.Name())
-	if _, err := c.writeState(dst); err != nil {
+	if _, err := c.writeState(s2.NewWriter(dst)); err != nil {
 		return err
 	}
 
@@ -109,10 +109,7 @@ func (c *Collection) isSnapshotting() (*commit.Log, bool) {
 
 // writeState writes collection state into the specified writer.
 func (c *Collection) writeState(dst io.Writer) (int64, error) {
-
-	// Create a writer, encoder and a reusable buffer
-	encoder := c.codec.EncoderFor(dst)
-	writer := iostream.NewWriter(c.codec.EncoderFor(dst))
+	writer := iostream.NewWriter(dst)
 	buffer := c.txns.acquirePage(rowColumn)
 	defer c.txns.releasePage(buffer)
 
@@ -173,13 +170,13 @@ func (c *Collection) writeState(dst io.Writer) (int64, error) {
 		return writer.Offset(), err
 	}
 
-	return writer.Offset(), encoder.Close()
+	return writer.Offset(), writer.Flush()
 }
 
 // readState reads a collection snapshotted state from the underlying reader. It
 // returns the last commit IDs for each chunk.
 func (c *Collection) readState(src io.Reader) ([]uint64, error) {
-	r := iostream.NewReader(c.codec.DecoderFor(src))
+	r := iostream.NewReader(src)
 	commits := make([]uint64, 128)
 
 	// Read the version and make sure it matches
@@ -220,46 +217,4 @@ func (c *Collection) readState(src io.Reader) ([]uint64, error) {
 			return nil
 		})
 	})
-}
-
-// --------------------------- Compression Codec ----------------------------
-
-// newCodec creates a new compressor for the destination writer
-func newCodec(options *Options) codec {
-	return &s2codec{
-		w: s2.NewWriter(nil),
-		r: s2.NewReader(nil),
-	}
-}
-
-type codec interface {
-	DecoderFor(reader io.Reader) io.Reader
-	EncoderFor(writer io.Writer) io.WriteCloser
-}
-
-type s2codec struct {
-	w *s2.Writer
-	r *s2.Reader
-}
-
-func (c *s2codec) Read(p []byte) (int, error) {
-	return c.r.Read(p)
-}
-
-func (c *s2codec) Write(p []byte) (int, error) {
-	return c.w.Write(p)
-}
-
-func (c *s2codec) DecoderFor(reader io.Reader) io.Reader {
-	c.r.Reset(reader)
-	return c
-}
-
-func (c *s2codec) EncoderFor(writer io.Writer) io.WriteCloser {
-	c.w.Reset(writer)
-	return c
-}
-
-func (c *s2codec) Close() error {
-	return c.w.Close()
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -428,6 +428,7 @@ func TestUpdateAt(t *testing.T) {
 	})
 
 	assert.NoError(t, c.UpdateAt(index, "col1", func(v Cursor) error {
+		assert.Equal(t, index, v.Index())
 		v.Set("hi")
 		return nil
 	}))


### PR DESCRIPTION
This PR contains minor refactoring of snapshot, and it is now also used when building an index for existing data instead of a special case `Update` function that is now deleted.