### PR TITLE
Allow reads during snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ players := NewCollection(column.Options{
 // Read the changes from the channel
 go func(){
 	for commit := writer{
-		println("commit", commit.Type.String())
+		println("commit", commit.ID)
 	}
 }()
 

--- a/commit/reader.go
+++ b/commit/reader.go
@@ -236,25 +236,6 @@ func (r *Reader) Range(buf *Buffer, chunk Chunk, fn func(*Reader)) {
 	}
 }
 
-// MaxOffset returns the maximum offset for a chunk
-func (r *Reader) MaxOffset(buf *Buffer, chunk Chunk) (max uint32) {
-	if buf == nil {
-		return
-	}
-
-	r.Range(buf, chunk, func(r *Reader) {
-		for r.Next() {
-			if max < r.Index() {
-				max = r.Index()
-			}
-		}
-	})
-
-	// Rewind after this, so we can re-use the reader after
-	r.Rewind()
-	return
-}
-
 // --------------------------- Next Iterator ----------------------------
 
 // Next reads the current operation and returns false if there is no more

--- a/commit/reader_test.go
+++ b/commit/reader_test.go
@@ -234,32 +234,6 @@ func TestReadFloatMixedSize(t *testing.T) {
 	})
 }
 
-func TestReaderMax(t *testing.T) {
-	buf := NewBuffer(0)
-	buf.Reset("test")
-	for i := uint32(0); i < 20000; i++ {
-		buf.PutUint64(Put, i, 2*uint64(i))
-	}
-
-	r := NewReader()
-	assert.Equal(t, 16383, int(r.MaxOffset(buf, 0)))
-	assert.Equal(t, 19999, int(r.MaxOffset(buf, 1)))
-	assert.Equal(t, 0, int(r.MaxOffset(nil, 0)))
-}
-
-func TestRewindAfterMax(t *testing.T) {
-	buf := NewBuffer(0)
-	buf.Reset("test")
-	for i := uint32(0); i < 10; i++ {
-		buf.PutUint64(Put, i, 2*uint64(i))
-	}
-
-	r := NewReader()
-	assert.Equal(t, 9, int(r.MaxOffset(buf, 0)))
-	assert.True(t, r.Next())
-	assert.Equal(t, 0, int(r.Index()))
-}
-
 func TestReadSize(t *testing.T) {
 	buf := NewBuffer(0)
 	buf.Reset("test")

--- a/snapshot.go
+++ b/snapshot.go
@@ -129,13 +129,11 @@ func (c *Collection) writeState(dst io.Writer) (int64, error) {
 
 	// Write each chunk
 	if err := writer.WriteRange(chunks, func(i int, w *iostream.Writer) error {
-		chunk := commit.Chunk(i)
-		return c.writeAtChunk(chunk, func(chunk commit.Chunk, fill bitmap.Bitmap) error {
+		return c.readChunk(commit.Chunk(i), func(lastCommit uint64, chunk commit.Chunk, fill bitmap.Bitmap) error {
 			offset := chunk.Min()
 
 			// Write the last written commit for this chunk
-			commitID := c.commits[chunk]
-			if err := writer.WriteUvarint(uint64(commitID)); err != nil {
+			if err := writer.WriteUvarint(lastCommit); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
This PR fixes the issue where during the snapshot the write lock was acquired, not allowing concurrent reads on the same chunk.