### PR TITLE
Use reader in restore

### DIFF
--- a/commit/log.go
+++ b/commit/log.go
@@ -38,18 +38,22 @@ func (w *Channel) Append(commit Commit) error {
 // during a snapshot. It also supports reading a commit log back.
 type Log struct {
 	lock   sync.Mutex
-	source io.ReadWriter
+	source io.Reader
 	writer *iostream.Writer
 	reader *iostream.Reader
 }
 
 // Open opens a commit log stream for both read and write.
-func Open(source io.ReadWriter) *Log {
-	return &Log{
+func Open(source io.Reader) *Log {
+	log := &Log{
 		source: source,
-		writer: iostream.NewWriter(s2.NewWriter(source)),
 		reader: iostream.NewReader(s2.NewReader(source)),
 	}
+
+	if rw, ok := source.(io.Writer); ok {
+		log.writer = iostream.NewWriter(s2.NewWriter(rw))
+	}
+	return log
 }
 
 // OpenFile opens a specified commit log file in a read/write mode. If

--- a/snapshot.go
+++ b/snapshot.go
@@ -40,7 +40,7 @@ func (c *Collection) Replay(change commit.Commit) error {
 
 // Restore restores the collection from the underlying snapshot reader. This operation
 // should be called before any of transactions, right after initialization.
-func (c *Collection) Restore(snapshot io.ReadWriter) error {
+func (c *Collection) Restore(snapshot io.Reader) error {
 	commits, err := c.readState(s2.NewReader(snapshot))
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR changes the signature of `Restore` from `Restore(io.ReadWriter) error` to `Restore(io.Reader) error` in order to simplify what needs to be passed to it.