### PR TITLE
Adjust multiple comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ players.InsertObjectWithTTL(map[string]interface{}{
 }, 5 * time.Second) // The time-to-live of 5 seconds
 ```
 
-On an interestig node, since `expire` column which is automatically added to each collection is an actual normal column, you can query and even update it. In the example below we query and conditionally update the expiration column. The example loads a time, adds one hour and updates it, but in practice if you want to do it you should use `Add()` method which can perform this atomically.
+On an interesting note, since `expire` column which is automatically added to each collection is an actual normal column, you can query and even update it. In the example below we query and conditionally update the expiration column. The example loads a time, adds one hour and updates it, but in practice if you want to do it you should use `Add()` method which can perform this atomically.
 
 ```go
 players.Query(func(txn *column.Txn) error {

--- a/collection.go
+++ b/collection.go
@@ -138,7 +138,7 @@ func (c *Collection) InsertObjectWithTTL(obj Object, ttl time.Duration) (index u
 	return
 }
 
-// Insert executes a mutable cursor trasactionally at a new offset.
+// Insert executes a mutable cursor transactionally at a new offset.
 func (c *Collection) Insert(fn func(Row) error) (index uint32, err error) {
 	err = c.Query(func(txn *Txn) (innerErr error) {
 		index, innerErr = txn.Insert(fn)
@@ -147,7 +147,7 @@ func (c *Collection) Insert(fn func(Row) error) (index uint32, err error) {
 	return
 }
 
-// InsertWithTTL executes a mutable cursor trasactionally at a new offset and sets the expiration time
+// InsertWithTTL executes a mutable cursor transactionally at a new offset and sets the expiration time
 // based on the specified time-to-live and returns the allocated index.
 func (c *Collection) InsertWithTTL(ttl time.Duration, fn func(Row) error) (index uint32, err error) {
 	err = c.Query(func(txn *Txn) (innerErr error) {

--- a/column.go
+++ b/column.go
@@ -141,12 +141,12 @@ func (c *column) IsIndex() bool {
 	return ok
 }
 
-// Is checks whether a column type supports certain numerical operations.
+// IsNumeric checks whether a column type supports certain numerical operations.
 func (c *column) IsNumeric() bool {
 	return (c.kind & typeNumeric) == typeNumeric
 }
 
-// Is checks whether a column type supports certain string operations.
+// IsTextual checks whether a column type supports certain string operations.
 func (c *column) IsTextual() bool {
 	return (c.kind & typeTextual) == typeTextual
 }
@@ -238,7 +238,7 @@ func (c *columnBool) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	dst.PutBitmap(commit.PutTrue, chunk, c.data)
 }
 
-// boolReader represens a read-only accessor for boolean values
+// boolReader represents a read-only accessor for boolean values
 type boolReader struct {
 	cursor *uint32
 	reader Column
@@ -273,7 +273,7 @@ func (s boolWriter) Set(value bool) {
 	s.writer.PutBool(*s.cursor, value)
 }
 
-// String returns a string column accessor
+// Bool returns a bool column accessor
 func (txn *Txn) Bool(columnName string) boolWriter {
 	return boolWriter{
 		boolReader: boolReaderFor(txn, columnName),
@@ -283,7 +283,7 @@ func (txn *Txn) Bool(columnName string) boolWriter {
 
 // --------------------------- Accessor ----------------------------
 
-// anyReader represens a read-only accessor for any value
+// anyReader represents a read-only accessor for any value
 type anyReader struct {
 	cursor *uint32
 	reader Column

--- a/column_generate.go
+++ b/column_generate.go
@@ -154,7 +154,7 @@ func (c *numberColumn) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// numberReader represens a read-only accessor for number
+// numberReader represents a read-only accessor for number
 type numberReader struct {
 	cursor *uint32
 	reader *numberColumn

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -151,7 +151,7 @@ func (c *float32Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// float32Reader represens a read-only accessor for float32
+// float32Reader represents a read-only accessor for float32
 type float32Reader struct {
 	cursor *uint32
 	reader *float32Column
@@ -345,7 +345,7 @@ func (c *float64Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// float64Reader represens a read-only accessor for float64
+// float64Reader represents a read-only accessor for float64
 type float64Reader struct {
 	cursor *uint32
 	reader *float64Column
@@ -539,7 +539,7 @@ func (c *intColumn) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// intReader represens a read-only accessor for int
+// intReader represents a read-only accessor for int
 type intReader struct {
 	cursor *uint32
 	reader *intColumn
@@ -733,7 +733,7 @@ func (c *int16Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// int16Reader represens a read-only accessor for int16
+// int16Reader represents a read-only accessor for int16
 type int16Reader struct {
 	cursor *uint32
 	reader *int16Column
@@ -927,7 +927,7 @@ func (c *int32Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// int32Reader represens a read-only accessor for int32
+// int32Reader represents a read-only accessor for int32
 type int32Reader struct {
 	cursor *uint32
 	reader *int32Column
@@ -1121,7 +1121,7 @@ func (c *int64Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// int64Reader represens a read-only accessor for int64
+// int64Reader represents a read-only accessor for int64
 type int64Reader struct {
 	cursor *uint32
 	reader *int64Column
@@ -1315,7 +1315,7 @@ func (c *uintColumn) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// uintReader represens a read-only accessor for uint
+// uintReader represents a read-only accessor for uint
 type uintReader struct {
 	cursor *uint32
 	reader *uintColumn
@@ -1509,7 +1509,7 @@ func (c *uint16Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// uint16Reader represens a read-only accessor for uint16
+// uint16Reader represents a read-only accessor for uint16
 type uint16Reader struct {
 	cursor *uint32
 	reader *uint16Column
@@ -1703,7 +1703,7 @@ func (c *uint32Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// uint32Reader represens a read-only accessor for uint32
+// uint32Reader represents a read-only accessor for uint32
 type uint32Reader struct {
 	cursor *uint32
 	reader *uint32Column
@@ -1897,7 +1897,7 @@ func (c *uint64Column) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// uint64Reader represens a read-only accessor for uint64
+// uint64Reader represents a read-only accessor for uint64
 type uint64Reader struct {
 	cursor *uint32
 	reader *uint64Column

--- a/column_strings.go
+++ b/column_strings.go
@@ -145,7 +145,7 @@ func (c *columnEnum) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// enumReader represens a read-only accessor for enum strings
+// enumReader represents a read-only accessor for enum strings
 type enumReader struct {
 	cursor *uint32
 	reader *columnEnum
@@ -286,7 +286,7 @@ func (c *columnString) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	})
 }
 
-// stringReader represens a read-only accessor for strings
+// stringReader represents a read-only accessor for strings
 type stringReader struct {
 	cursor *uint32
 	reader *columnString

--- a/txn.go
+++ b/txn.go
@@ -118,7 +118,7 @@ func (txn *Txn) bufferFor(columnName string) *commit.Buffer {
 // common operation.
 type columnCache struct {
 	name string  // The column name
-	col  *column // The columns and its computed
+	col  *column // The loaded column
 }
 
 // columnAt loads and caches the column for the transaction
@@ -320,12 +320,12 @@ func (txn *Txn) InsertObjectWithTTL(object Object, ttl time.Duration) (uint32, e
 	return txn.insertObject(object, time.Now().Add(ttl).UnixNano())
 }
 
-// Insert executes a mutable cursor trasactionally at a new offset.
+// Insert executes a mutable cursor transactionally at a new offset.
 func (txn *Txn) Insert(fn func(Row) error) (uint32, error) {
 	return txn.insert(fn, 0)
 }
 
-// InsertWithTTL executes a mutable cursor trasactionally at a new offset and sets the expiration time
+// InsertWithTTL executes a mutable cursor transactionally at a new offset and sets the expiration time
 // based on the specified time-to-live and returns the allocated index.
 func (txn *Txn) InsertWithTTL(ttl time.Duration, fn func(Row) error) (uint32, error) {
 	return txn.insert(fn, time.Now().Add(ttl).UnixNano())


### PR DESCRIPTION
This commit fixes a few spelling errors & comment mistakes across multiple files. There are no code behavior changes. 

In summary,
- Change ‘trasactionally’ → ‘transactionally’
- Change ‘respresens’ → ‘represents’
- Fix IsNumeric & IsTextual function comments
- Fix Txn.Bool function comments
- Adjust columnCache internal field’s comments