### PR TITLE
Add generic chunked storage to strings and numbers

### DIFF
--- a/column.go
+++ b/column.go
@@ -34,11 +34,6 @@ func typeOf(column Column) (typ columnType) {
 	return
 }
 
-type segment[T any] struct {
-	fill bitmap.Bitmap // The fill-list
-	data []T           // The actual values
-}
-
 // --------------------------- Contracts ----------------------------
 
 // Column represents a column implementation
@@ -197,102 +192,6 @@ func (c *column) Value(idx uint32) (v interface{}, ok bool) {
 	return
 }
 
-// --------------------------- booleans ----------------------------
-
-// columnBool represents a boolean column
-type columnBool struct {
-	data bitmap.Bitmap
-}
-
-// makeBools creates a new boolean column
-func makeBools() Column {
-	return &columnBool{
-		data: make(bitmap.Bitmap, 0, 4),
-	}
-}
-
-// Grow grows the size of the column until we have enough to store
-func (c *columnBool) Grow(idx uint32) {
-	c.data.Grow(idx)
-}
-
-// Apply applies a set of operations to the column.
-func (c *columnBool) Apply(chunk commit.Chunk, r *commit.Reader) {
-	for r.Next() {
-		v := uint64(1) << (r.Offset & 0x3f)
-		switch r.Type {
-		case commit.PutTrue:
-			c.data[r.Offset>>6] |= v
-		case commit.PutFalse: // also "delete"
-			c.data[r.Offset>>6] &^= v
-		}
-	}
-}
-
-// Value retrieves a value at a specified index
-func (c *columnBool) Value(idx uint32) (interface{}, bool) {
-	value := c.data.Contains(idx)
-	return value, value
-}
-
-// Contains checks whether the column has a value at a specified index.
-func (c *columnBool) Contains(idx uint32) bool {
-	return c.data.Contains(idx)
-}
-
-// Index returns the fill list for the column
-func (c *columnBool) Index(chunk commit.Chunk) bitmap.Bitmap {
-	return chunk.OfBitmap(c.data)
-}
-
-// Snapshot writes the entire column into the specified destination buffer
-func (c *columnBool) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
-	dst.PutBitmap(commit.PutTrue, chunk, c.data)
-}
-
-// boolReader represents a read-only accessor for boolean values
-type boolReader struct {
-	cursor *uint32
-	reader Column
-}
-
-// Get loads the value at the current transaction cursor
-func (s boolReader) Get() bool {
-	return s.reader.Contains(*s.cursor)
-}
-
-// boolReaderFor creates a new reader
-func boolReaderFor(txn *Txn, columnName string) boolReader {
-	column, ok := txn.columnAt(columnName)
-	if !ok {
-		panic(fmt.Errorf("column: column '%s' does not exist", columnName))
-	}
-
-	return boolReader{
-		cursor: &txn.cursor,
-		reader: column.Column,
-	}
-}
-
-// boolWriter represents read-write accessor for boolean values
-type boolWriter struct {
-	boolReader
-	writer *commit.Buffer
-}
-
-// Set sets the value at the current transaction cursor
-func (s boolWriter) Set(value bool) {
-	s.writer.PutBool(*s.cursor, value)
-}
-
-// Bool returns a bool column accessor
-func (txn *Txn) Bool(columnName string) boolWriter {
-	return boolWriter{
-		boolReader: boolReaderFor(txn, columnName),
-		writer:     txn.bufferFor(columnName),
-	}
-}
-
 // --------------------------- Accessor ----------------------------
 
 // anyReader represents a read-only accessor for any value
@@ -302,7 +201,7 @@ type anyReader struct {
 }
 
 // Get loads the value at the current transaction cursor
-func (s anyReader) Get() (interface{}, bool) {
+func (s anyReader) Get() (any, bool) {
 	return s.reader.Value(*s.cursor)
 }
 
@@ -326,7 +225,7 @@ type anyWriter struct {
 }
 
 // Set sets the value at the current transaction cursor
-func (s anyWriter) Set(value interface{}) {
+func (s anyWriter) Set(value any) {
 	s.writer.PutAny(commit.Put, *s.cursor, value)
 }
 
@@ -338,27 +237,39 @@ func (txn *Txn) Any(columnName string) anyWriter {
 	}
 }
 
-// --------------------------- funcs ----------------------------
+// --------------------------- segment list ----------------------------
 
-// resize calculates the new required capacity and a new index
-func resize(capacity int, v uint32) int {
-	const threshold = 256
-	if v < threshold {
-		v |= v >> 1
-		v |= v >> 2
-		v |= v >> 4
-		v |= v >> 8
-		v |= v >> 16
-		v++
-		return int(v)
-	}
+// Chunks represents a chunked array storage
+type chunks[T any] []struct {
+	fill bitmap.Bitmap // The fill-list
+	data []T           // The actual values
+}
 
-	if capacity < threshold {
-		capacity = threshold
-	}
+// chunkAt loads the fill and data list at a particular chunk
+func (s chunks[T]) chunkAt(chunk commit.Chunk) (bitmap.Bitmap, []T) {
+	fill := s[chunk].fill
+	data := s[chunk].data
+	return fill, data
+}
 
-	for 0 < capacity && capacity < int(v+1) {
-		capacity += (capacity + 3*threshold) / 4
+// Grow grows a segment list
+func (s *chunks[T]) Grow(idx uint32) {
+	chunk := int(commit.ChunkAt(idx))
+	for i := len(*s); i <= chunk; i++ {
+		*s = append(*s, struct {
+			fill bitmap.Bitmap
+			data []T
+		}{
+			fill: make(bitmap.Bitmap, chunkSize/64),
+			data: make([]T, chunkSize),
+		})
 	}
-	return capacity
+}
+
+// Index returns the fill list for the segment
+func (s chunks[T]) Index(chunk commit.Chunk) (fill bitmap.Bitmap) {
+	if int(chunk) < len(s) {
+		fill = s[chunk].fill
+	}
+	return
 }

--- a/column_bool.go
+++ b/column_bool.go
@@ -1,0 +1,105 @@
+// Copyright (c) Roman Atachiants and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+package column
+
+import (
+	"fmt"
+
+	"github.com/kelindar/bitmap"
+	"github.com/kelindar/column/commit"
+)
+
+// columnBool represents a boolean column
+type columnBool struct {
+	data bitmap.Bitmap
+}
+
+// makeBools creates a new boolean column
+func makeBools() Column {
+	return &columnBool{
+		data: make(bitmap.Bitmap, 0, 4),
+	}
+}
+
+// Grow grows the size of the column until we have enough to store
+func (c *columnBool) Grow(idx uint32) {
+	c.data.Grow(idx)
+}
+
+// Apply applies a set of operations to the column.
+func (c *columnBool) Apply(chunk commit.Chunk, r *commit.Reader) {
+	for r.Next() {
+		v := uint64(1) << (r.Offset & 0x3f)
+		switch r.Type {
+		case commit.PutTrue:
+			c.data[r.Offset>>6] |= v
+		case commit.PutFalse: // also "delete"
+			c.data[r.Offset>>6] &^= v
+		}
+	}
+}
+
+// Value retrieves a value at a specified index
+func (c *columnBool) Value(idx uint32) (interface{}, bool) {
+	value := c.data.Contains(idx)
+	return value, value
+}
+
+// Contains checks whether the column has a value at a specified index.
+func (c *columnBool) Contains(idx uint32) bool {
+	return c.data.Contains(idx)
+}
+
+// Index returns the fill list for the column
+func (c *columnBool) Index(chunk commit.Chunk) bitmap.Bitmap {
+	return chunk.OfBitmap(c.data)
+}
+
+// Snapshot writes the entire column into the specified destination buffer
+func (c *columnBool) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	dst.PutBitmap(commit.PutTrue, chunk, c.data)
+}
+
+// boolReader represents a read-only accessor for boolean values
+type boolReader struct {
+	cursor *uint32
+	reader Column
+}
+
+// Get loads the value at the current transaction cursor
+func (s boolReader) Get() bool {
+	return s.reader.Contains(*s.cursor)
+}
+
+// boolReaderFor creates a new reader
+func boolReaderFor(txn *Txn, columnName string) boolReader {
+	column, ok := txn.columnAt(columnName)
+	if !ok {
+		panic(fmt.Errorf("column: column '%s' does not exist", columnName))
+	}
+
+	return boolReader{
+		cursor: &txn.cursor,
+		reader: column.Column,
+	}
+}
+
+// boolWriter represents read-write accessor for boolean values
+type boolWriter struct {
+	boolReader
+	writer *commit.Buffer
+}
+
+// Set sets the value at the current transaction cursor
+func (s boolWriter) Set(value bool) {
+	s.writer.PutBool(*s.cursor, value)
+}
+
+// Bool returns a bool column accessor
+func (txn *Txn) Bool(columnName string) boolWriter {
+	return boolWriter{
+		boolReader: boolReaderFor(txn, columnName),
+		writer:     txn.bufferFor(columnName),
+	}
+}

--- a/column_index.go
+++ b/column_index.go
@@ -4,9 +4,6 @@
 package column
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/kelindar/bitmap"
 	"github.com/kelindar/column/commit"
 )
@@ -101,89 +98,4 @@ func (c *columnIndex) Index(chunk commit.Chunk) bitmap.Bitmap {
 // Snapshot writes the entire column into the specified destination buffer
 func (c *columnIndex) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	dst.PutBitmap(commit.PutTrue, chunk, c.fill)
-}
-
-// --------------------------- Key ----------------------------
-
-// columnKey represents the primary key column implementation
-type columnKey struct {
-	columnString
-	name string            // Name of the column
-	lock sync.RWMutex      // Lock to protect the lookup table
-	seek map[string]uint32 // Lookup table for O(1) index seek
-}
-
-// makeKey creates a new primary key column
-func makeKey() Column {
-	return &columnKey{
-		seek: make(map[string]uint32, 64),
-		columnString: columnString{
-			data: make([]segment[string], 0, 4),
-		},
-	}
-}
-
-// Apply applies a set of operations to the column.
-func (c *columnKey) Apply(chunk commit.Chunk, r *commit.Reader) {
-	fill := c.data[chunk].fill
-	data := c.data[chunk].data
-	from := chunk.Min()
-
-	for r.Next() {
-		offset := r.Offset - int32(from)
-		switch r.Type {
-		case commit.Put:
-			value := string(r.Bytes())
-
-			fill[offset>>6] |= 1 << (offset & 0x3f)
-			data[offset] = value
-			c.lock.Lock()
-			c.seek[value] = uint32(r.Offset)
-			c.lock.Unlock()
-
-		case commit.Delete:
-			fill.Remove(uint32(offset))
-			c.lock.Lock()
-			delete(c.seek, string(data[offset]))
-			c.lock.Unlock()
-		}
-	}
-}
-
-// OffsetOf returns the offset for a particular value
-func (c *columnKey) OffsetOf(v string) (uint32, bool) {
-	c.lock.RLock()
-	idx, ok := c.seek[v]
-	c.lock.RUnlock()
-	return idx, ok
-}
-
-// slice accessor for keys
-type keySlice struct {
-	cursor *uint32
-	writer *commit.Buffer
-	reader *columnKey
-}
-
-// Set sets the value at the current transaction index
-func (s keySlice) Set(value string) {
-	s.writer.PutString(commit.Put, *s.cursor, value)
-}
-
-// Get loads the value at the current transaction index
-func (s keySlice) Get() (string, bool) {
-	return s.reader.LoadString(*s.cursor)
-}
-
-// Enum returns a enumerable column accessor
-func (txn *Txn) Key() keySlice {
-	if txn.owner.pk == nil {
-		panic(fmt.Errorf("column: primary key column does not exist"))
-	}
-
-	return keySlice{
-		cursor: &txn.cursor,
-		writer: txn.bufferFor(txn.owner.pk.name),
-		reader: txn.owner.pk,
-	}
 }

--- a/column_key.go
+++ b/column_key.go
@@ -1,0 +1,95 @@
+// Copyright (c) Roman Atachiants and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+package column
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kelindar/column/commit"
+)
+
+// --------------------------- Key ----------------------------
+
+// columnKey represents the primary key column implementation
+type columnKey struct {
+	columnString
+	name string            // Name of the column
+	lock sync.RWMutex      // Lock to protect the lookup table
+	seek map[string]uint32 // Lookup table for O(1) index seek
+}
+
+// makeKey creates a new primary key column
+func makeKey() Column {
+	return &columnKey{
+		seek: make(map[string]uint32, 64),
+		columnString: columnString{
+			chunks: make(chunks[string], 0, 4),
+		},
+	}
+}
+
+// Apply applies a set of operations to the column.
+func (c *columnKey) Apply(chunk commit.Chunk, r *commit.Reader) {
+	fill, data := c.chunkAt(chunk)
+	from := chunk.Min()
+
+	for r.Next() {
+		offset := r.Offset - int32(from)
+		switch r.Type {
+		case commit.Put:
+			value := string(r.Bytes())
+
+			fill[offset>>6] |= 1 << (offset & 0x3f)
+			data[offset] = value
+			c.lock.Lock()
+			c.seek[value] = uint32(r.Offset)
+			c.lock.Unlock()
+
+		case commit.Delete:
+			fill.Remove(uint32(offset))
+			c.lock.Lock()
+			delete(c.seek, string(data[offset]))
+			c.lock.Unlock()
+		}
+	}
+}
+
+// OffsetOf returns the offset for a particular value
+func (c *columnKey) OffsetOf(v string) (uint32, bool) {
+	c.lock.RLock()
+	idx, ok := c.seek[v]
+	c.lock.RUnlock()
+	return idx, ok
+}
+
+// slice accessor for keys
+type keySlice struct {
+	cursor *uint32
+	writer *commit.Buffer
+	reader *columnKey
+}
+
+// Set sets the value at the current transaction index
+func (s keySlice) Set(value string) {
+	s.writer.PutString(commit.Put, *s.cursor, value)
+}
+
+// Get loads the value at the current transaction index
+func (s keySlice) Get() (string, bool) {
+	return s.reader.LoadString(*s.cursor)
+}
+
+// Enum returns a enumerable column accessor
+func (txn *Txn) Key() keySlice {
+	if txn.owner.pk == nil {
+		panic(fmt.Errorf("column: primary key column does not exist"))
+	}
+
+	return keySlice{
+		cursor: &txn.cursor,
+		writer: txn.bufferFor(txn.owner.pk.name),
+		reader: txn.owner.pk,
+	}
+}

--- a/column_strings.go
+++ b/column_strings.go
@@ -19,51 +19,31 @@ var _ Textual = new(columnEnum)
 
 // columnEnum represents a string column
 type columnEnum struct {
-	fill bitmap.Bitmap // The fill-list
-	locs []uint32      // The list of locations
-	seek *intmap.Sync  // The hash->location table
-	data []string      // The string data
+	chunks[uint32]
+	seek *intmap.Sync // The hash->location table
+	data []string     // The string data
 }
 
 // makeEnum creates a new column
 func makeEnum() Column {
 	return &columnEnum{
-		fill: make(bitmap.Bitmap, 0, 4),
-		locs: make([]uint32, 0, 64),
-		seek: intmap.NewSync(64, .95),
-		data: make([]string, 0, 64),
+		chunks: make(chunks[uint32], 0, 4),
+		seek:   intmap.NewSync(64, .95),
+		data:   make([]string, 0, 64),
 	}
-}
-
-// Grow grows the size of the column until we have enough to store
-func (c *columnEnum) Grow(idx uint32) {
-	if idx < uint32(len(c.locs)) {
-		return
-	}
-
-	if idx < uint32(cap(c.locs)) {
-		c.fill.Grow(idx)
-		c.locs = c.locs[:idx+1]
-		return
-	}
-
-	c.fill.Grow(idx)
-	clone := make([]uint32, idx+1, resize(cap(c.locs), idx+1))
-	copy(clone, c.locs)
-	c.locs = clone
 }
 
 // Apply applies a set of operations to the column.
 func (c *columnEnum) Apply(chunk commit.Chunk, r *commit.Reader) {
+	fill, locs := c.chunkAt(chunk)
 	for r.Next() {
+		offset := r.IndexAtChunk()
 		switch r.Type {
 		case commit.Put:
-			// Set the value at the index
-			c.fill[r.Offset>>6] |= 1 << (r.Offset & 0x3f)
-			c.locs[r.Offset] = c.findOrAdd(r.Bytes())
-
+			fill[offset>>6] |= 1 << (offset & 0x3f)
+			locs[offset] = c.findOrAdd(r.Bytes())
 		case commit.Delete:
-			c.fill.Remove(r.Index())
+			fill.Remove(offset)
 			// TODO: remove unused strings, need some reference counting for that
 			// and can proably be done during vacuum() instead
 		}
@@ -92,8 +72,10 @@ func (c *columnEnum) Value(idx uint32) (v interface{}, ok bool) {
 
 // LoadString retrieves a value at a specified index
 func (c *columnEnum) LoadString(idx uint32) (v string, ok bool) {
-	if idx < uint32(len(c.locs)) && c.fill.Contains(idx) {
-		v, ok = c.readAt(c.locs[idx]), true
+	chunk := commit.ChunkAt(idx)
+	index := idx - chunk.Min()
+	if int(chunk) < len(c.chunks) && c.chunks[chunk].fill.Contains(index) {
+		v, ok = c.readAt(c.chunks[chunk].data[idx]), true
 	}
 	return
 }
@@ -101,8 +83,11 @@ func (c *columnEnum) LoadString(idx uint32) (v string, ok bool) {
 // FilterString filters down the values based on the specified predicate. The column for
 // this filter must be a string.
 func (c *columnEnum) FilterString(chunk commit.Chunk, index bitmap.Bitmap, predicate func(v string) bool) {
-	offset := chunk.Min()
+	if int(chunk) >= len(c.chunks) {
+		return
+	}
 
+	fill, locs := c.chunkAt(chunk)
 	cache := struct {
 		index uint32 // Last seen offset
 		value bool   // Last evaluated predicate
@@ -113,13 +98,12 @@ func (c *columnEnum) FilterString(chunk commit.Chunk, index bitmap.Bitmap, predi
 
 	// Do a quick ellimination of elements which are NOT contained in this column, this
 	// allows us not to check contains during the filter itself
-	index.And(c.fill[offset>>6 : int(offset>>6)+len(index)])
+	index.And(fill)
 
 	// Filters down the strings, if strings repeat we avoid reading every time by
 	// caching the last seen index/value combination.
 	index.Filter(func(idx uint32) bool {
-		idx = offset + idx
-		if at := c.locs[idx]; at != cache.index {
+		if at := locs[idx]; at != cache.index {
 			cache.index = at
 			cache.value = predicate(c.readAt(at))
 			return cache.value
@@ -132,18 +116,15 @@ func (c *columnEnum) FilterString(chunk commit.Chunk, index bitmap.Bitmap, predi
 
 // Contains checks whether the column has a value at a specified index.
 func (c *columnEnum) Contains(idx uint32) bool {
-	return c.fill.Contains(idx)
-}
-
-// Index returns the fill list for the column
-func (c *columnEnum) Index(chunk commit.Chunk) bitmap.Bitmap {
-	return chunk.OfBitmap(c.fill)
+	chunk := commit.ChunkAt(idx)
+	return c.chunks[chunk].fill.Contains(idx - chunk.Min())
 }
 
 // Snapshot writes the entire column into the specified destination buffer
 func (c *columnEnum) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
-	chunk.Range(c.fill, func(idx uint32) {
-		dst.PutString(commit.Put, idx, c.readAt(c.locs[idx]))
+	fill, locs := c.chunkAt(chunk)
+	fill.Range(func(idx uint32) {
+		dst.PutString(commit.Put, idx, c.readAt(locs[idx]))
 	})
 }
 
@@ -201,38 +182,19 @@ var _ Textual = new(columnString)
 
 // columnString represents a string column
 type columnString struct {
-	data []segment[string]
+	chunks[string]
 }
 
 // makeString creates a new string column
 func makeStrings() Column {
 	return &columnString{
-		data: make([]segment[string], 0, 4),
-	}
-}
-
-// segmentAt loads the fill and data list at a particular chunk
-func (c *columnString) segmentAt(chunk commit.Chunk) (bitmap.Bitmap, []string) {
-	fill := c.data[chunk].fill
-	data := c.data[chunk].data
-	return fill, data
-}
-
-// Grow grows the size of the column until we have enough to store
-func (c *columnString) Grow(idx uint32) {
-	chunk := int(commit.ChunkAt(idx))
-	for i := len(c.data); i <= chunk; i++ {
-		c.data = append(c.data, segment[string]{
-			fill: make(bitmap.Bitmap, chunkSize/64),
-			data: make([]string, chunkSize),
-		})
+		chunks: make(chunks[string], 0, 4),
 	}
 }
 
 // Apply applies a set of operations to the column.
 func (c *columnString) Apply(chunk commit.Chunk, r *commit.Reader) {
-	fill := c.data[chunk].fill
-	data := c.data[chunk].data
+	fill, data := c.chunkAt(chunk)
 	from := chunk.Min()
 
 	// Update the values of the column, for this one we can only process stores
@@ -253,8 +215,8 @@ func (c *columnString) Value(idx uint32) (v interface{}, ok bool) {
 	chunk := commit.ChunkAt(idx)
 	index := idx - chunk.Min()
 
-	if int(chunk) < len(c.data) && c.data[chunk].fill.Contains(index) {
-		v, ok = c.data[chunk].data[index], true
+	if int(chunk) < len(c.chunks) && c.chunks[chunk].fill.Contains(index) {
+		v, ok = c.chunks[chunk].data[index], true
 	}
 	return
 }
@@ -263,16 +225,8 @@ func (c *columnString) Value(idx uint32) (v interface{}, ok bool) {
 func (c *columnString) Contains(idx uint32) bool {
 	chunk := commit.ChunkAt(idx)
 	index := idx - chunk.Min()
-	return c.data[chunk].fill.Contains(index)
+	return c.chunks[chunk].fill.Contains(index)
 
-}
-
-// Index returns the fill list for the column
-func (c *columnString) Index(chunk commit.Chunk) (fill bitmap.Bitmap) {
-	if int(chunk) < len(c.data) {
-		fill = c.data[chunk].fill
-	}
-	return
 }
 
 // LoadString retrieves a value at a specified index
@@ -285,8 +239,8 @@ func (c *columnString) LoadString(idx uint32) (string, bool) {
 // FilterString filters down the values based on the specified predicate. The column for
 // this filter must be a string.
 func (c *columnString) FilterString(chunk commit.Chunk, index bitmap.Bitmap, predicate func(v string) bool) {
-	if int(chunk) < len(c.data) {
-		fill, data := c.segmentAt(chunk)
+	if int(chunk) < len(c.chunks) {
+		fill, data := c.chunkAt(chunk)
 		index.And(fill)
 		index.Filter(func(idx uint32) bool {
 			return predicate(data[idx])
@@ -296,8 +250,7 @@ func (c *columnString) FilterString(chunk commit.Chunk, index bitmap.Bitmap, pre
 
 // Snapshot writes the entire column into the specified destination buffer
 func (c *columnString) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
-	data := c.data[chunk].data
-	fill := c.data[chunk].fill
+	fill, data := c.chunkAt(chunk)
 	fill.Range(func(x uint32) {
 		dst.PutString(commit.Put, chunk.Min()+x, data[x])
 	})

--- a/column_test.go
+++ b/column_test.go
@@ -337,20 +337,6 @@ func TestSnapshotIndex(t *testing.T) {
 	assert.Equal(t, input.Column.(*columnIndex).fill, output.Column.(*columnIndex).fill)
 }
 
-func TestResize(t *testing.T) {
-	assert.Equal(t, 1, resize(100, 0))
-	assert.Equal(t, 2, resize(100, 1))
-	assert.Equal(t, 4, resize(100, 2))
-	assert.Equal(t, 16, resize(100, 11))
-	assert.Equal(t, 256, resize(100, 255))
-	assert.Equal(t, 1232, resize(100, 1000))
-	assert.Equal(t, 1232, resize(200, 1000))
-	assert.Equal(t, 1232, resize(512, 1000))
-	assert.Equal(t, 1213, resize(500, 1000)) // Inconsistent
-	assert.Equal(t, 22504, resize(512, 20000))
-	assert.Equal(t, 28322, resize(22504, 22600))
-}
-
 func TestAccessors(t *testing.T) {
 	tests := []struct {
 		column Column

--- a/examples/million/README.md
+++ b/examples/million/README.md
@@ -1,44 +1,40 @@
-# One Million Rows
+# Ten Million Rows
 
-This example adds one million rows to a collection, runs and measures a few different queries and transaction around it.
+This example adds 10 million rows to a collection, runs and measures a few different queries and transaction around it.
 
 ## Example output
 
 ```
-running insert of 1000000 rows...
+running insert of 10000000 rows...
 -> inserted 0 rows
--> inserted 100000 rows
--> inserted 200000 rows
--> inserted 300000 rows
--> inserted 400000 rows
--> inserted 500000 rows
--> inserted 600000 rows
--> inserted 700000 rows
--> inserted 800000 rows
--> inserted 900000 rows
--> insert took 1.0899436s
+...
+-> inserted 9900000 rows
+-> insert took 9.6700612s
+
+running snapshot of 10000000 rows...
+-> snapshot took 1.02656756s
 
 running full scan of age >= 30...
--> result = 510000
--> full scan took 2.834398ms
+-> result = 5100000
+-> full scan took 26.217664ms
 
 running full scan of class == "rogue"...
--> result = 358000
--> full scan took 4.381428ms
+-> result = 3580000
+-> full scan took 41.691512ms
 
 running indexed query of human mages...
--> result = 68000
--> indexed query took 17.813µs
+-> result = 680000
+-> indexed query took 269.734µs
 
 running indexed query of human female mages...
--> result = 32000
--> indexed query took 22.354µs
+-> result = 320000
+-> indexed query took 330.87µs
 
 running update of balance of everyone...
--> updated 1000000 rows
--> update took 11.882838ms
+-> updated 10000000 rows
+-> update took 101.451402ms
 
 running update of age of mages...
--> updated 302000 rows
--> update took 4.353562ms
+-> updated 3020000 rows
+-> update took 39.874322ms
 ```

--- a/examples/million/main.go
+++ b/examples/million/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	amount, runs := 1000000, 50
+	amount, runs := 10000000, 20
 	players := column.NewCollection(column.Options{
 		Capacity: amount,
 	})
@@ -143,10 +143,6 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 
 	// Load the data in
 	for i := 0; i < amount/len(data); i++ {
-		if i%200 == 0 {
-			fmt.Printf("-> inserted %v rows\n", out.Count())
-		}
-
 		out.Query(func(txn *column.Txn) error {
 			for _, p := range data {
 				txn.InsertObject(p)

--- a/txn_row.go
+++ b/txn_row.go
@@ -208,7 +208,7 @@ func (r Row) SetBool(columnName string, value bool) {
 }
 
 // Any loads a bool value at a particular column
-func (r Row) Any(columnName string) (interface{}, bool) {
+func (r Row) Any(columnName string) (any, bool) {
 	return anyReaderFor(r.txn, columnName).Get()
 }
 


### PR DESCRIPTION
This PR further removes unnecessary code duplication by adding a generic `chunks` storage that takes care of segmenting `fill` bitmap and `data` slices, in chunks of 16K.