### PR TITLE
Fixed loadstring index

### DIFF
--- a/column_numeric.go
+++ b/column_numeric.go
@@ -142,7 +142,6 @@ func (s numericReader[T]) Get() (T, bool) {
 
 // Sum computes the sum of the column values selected by the transaction
 func (s numericReader[T]) Sum() (r T) {
-	s.txn.initialize()
 	s.txn.Range(func(idx uint32) {
 		v, _ := s.Get()
 		r += v

--- a/column_strings.go
+++ b/column_strings.go
@@ -75,7 +75,7 @@ func (c *columnEnum) LoadString(idx uint32) (v string, ok bool) {
 	chunk := commit.ChunkAt(idx)
 	index := idx - chunk.Min()
 	if int(chunk) < len(c.chunks) && c.chunks[chunk].fill.Contains(index) {
-		v, ok = c.readAt(c.chunks[chunk].data[idx]), true
+		v, ok = c.readAt(c.chunks[chunk].data[index]), true
 	}
 	return
 }


### PR DESCRIPTION
Fixed an issue with `LoadString()` index out of bounds when accessing a second chunk.