### PR TITLE
Fix commit.Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ players.Query(func(txn *column.Txn) error {
 
 ## Streaming Changes
 
-This library also supports streaming out all transaction commits consistently, as they happen. This allows you to implement your own change data capture (CDC) listeners, stream data into kafka or into a remote database for durability. In order to enable it, you can simply provide an implementation of a `commit.Writer` interface during the creation of the collection.
+This library also supports streaming out all transaction commits consistently, as they happen. This allows you to implement your own change data capture (CDC) listeners, stream data into kafka or into a remote database for durability. In order to enable it, you can simply provide an implementation of a `commit.Logger` interface during the creation of the collection.
 
-In the example below we take advantage of the `commit.Channel` implementation of a `commit.Writer` which simply publishes the commits into a go channel. Here we create a buffered channel and keep consuming the commits with a separate goroutine, allowing us to view transactions as they happen in the store.
+In the example below we take advantage of the `commit.Channel` implementation of a `commit.Logger` which simply publishes the commits into a go channel. Here we create a buffered channel and keep consuming the commits with a separate goroutine, allowing us to view transactions as they happen in the store.
 
 ```go
 // Create a new commit writer (simple channel) and a new collection
@@ -319,8 +319,8 @@ players := NewCollection(column.Options{
 
 // Read the changes from the channel
 go func(){
-	for commit := writer{
-		println("commit", commit.ID)
+	for commit := range writer {
+		fmt.Printf("commit %v\n", commit.ID)
 	}
 }()
 

--- a/commit/log.go
+++ b/commit/log.go
@@ -27,8 +27,8 @@ var _ Logger = new(Log)
 type Channel chan Commit
 
 // Append clones the commit and writes it into the logger
-func (w *Channel) Append(commit Commit) error {
-	*w <- commit.Clone()
+func (w Channel) Append(commit Commit) error {
+	w <- commit.Clone()
 	return nil
 }
 


### PR DESCRIPTION
Was messing around with CDC and caught
~~~
./collection_test.go:553:11: cannot use w (variable of type commit.Channel) as type commit.Logger in struct literal:
        commit.Channel does not implement commit.Logger (Append method has pointer receiver)
~~~

This PR fixes commit.Channel and allows it to once again implement the Logger interface. It also adds a simple replication test. 