### PR TITLE
Fix snapshot race

### DIFF
--- a/txn_lock.go
+++ b/txn_lock.go
@@ -93,20 +93,3 @@ func (txn *Txn) rangeWrite(fn func(commitID uint64, chunk commit.Chunk, fill bit
 		lock.Unlock(uint(chunk))
 	})
 }
-
-// readChunk acquires appropriate locks for a chunk and executes a read callback
-func (c *Collection) readChunk(chunk commit.Chunk, fn func(uint64, commit.Chunk, bitmap.Bitmap) error) (err error) {
-	lock := c.slock
-	lock.RLock(uint(chunk))
-
-	// Compute the fill
-	c.lock.RLock()
-	fill := chunk.OfBitmap(c.fill)
-	commitID := c.commits[chunk]
-	c.lock.RUnlock()
-
-	// Call the delegate
-	err = fn(commitID, chunk, fill)
-	lock.RUnlock(uint(chunk))
-	return
-}


### PR DESCRIPTION
This should fix the following race

```
WARNING: DATA RACE
Write at 0x00c00432b000 by goroutine [9](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:10)1:
  github.com/kelindar/bitmap.(*Bitmap).Set()
      /home/runner/go/pkg/mod/github.com/kelindar/bitmap@v1.4.1/bitmap.go:27 +0xb3
  github.com/kelindar/column.(*Collection).next()
      /home/runner/work/column/column/collection.go:94 +0x84
  github.com/kelindar/column.(*Txn).insert()
      /home/runner/work/column/column/txn.go:336 +0x64
  github.com/kelindar/column.(*Txn).Insert()
      /home/runner/work/column/column/txn.go:329 +0xe9
  github.com/kelindar/column.(*Collection).Insert.func1()
      /home/runner/work/column/column/collection.go:152 +0x58
  github.com/kelindar/column.(*Collection).Query()
      /home/runner/work/column/column/collection.go:293 +0x73
  github.com/kelindar/column.(*Collection).Insert()
      /home/runner/work/column/column/collection.go:151 +0x84
  github.com/kelindar/column.TestSnapshotFailures.func3()
      /home/runner/work/column/column/snapshot_test.go:209 +0x47
Previous read at 0x00c00432b000 by goroutine 188:
  github.com/kelindar/bitmap.Bitmap.Range()
      /home/runner/go/pkg/mod/github.com/kelindar/bitmap@v1.4.1/range.go:17 +0x5a
  github.com/kelindar/column.(*Collection).writeState.func1.1()
      /home/runner/work/column/column/snapshot.go:142 +0x1cd
  github.com/kelindar/column.(*Collection).readChunk()
      /home/runner/work/column/column/txn_lock.go:[10](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:11)9 +0x210
  github.com/kelindar/column.(*Collection).writeState.func1()
      /home/runner/work/column/column/snapshot.go:[13](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:14)2 +0x9a
  github.com/kelindar/iostream.(*Writer).WriteRange()
      /home/runner/go/pkg/mod/github.com/kelindar/iostream@v1.3.0/writer.go:245 +0x98
  github.com/kelindar/column.(*Collection).writeState()
      /home/runner/work/column/column/snapshot.go:131 +0x2dc
  github.com/kelindar/column.(*Collection).Snapshot()
      /home/runner/work/column/column/snapshot.go:68 +0x164
  github.com/kelindar/column.TestSnapshotFailures()
      /home/runner/work/column/column/snapshot_test.go:217 +0x1a6
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:[14](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:15)39 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1486 +0x47
Goroutine 91 (running) created at:
  github.com/kelindar/column.TestSnapshotFailures()
      /home/runner/work/column/column/snapshot_test.go:209 +0x13c
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1486 +0x47
Goroutine 188 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.3/x64/src/testing/testing.go:[17](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:18)[19](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:20) +0xa71
  main.main()
      _testmain.go:[27](https://github.com/kelindar/column/runs/6852358984?check_suite_focus=true#step:5:28)5 +0x3a9
```