### PR TITLE
Expose race case with ubuntu container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+# docker build -t column_ubuntu_test . 
+FROM golang:1.18-bullseye
+
+WORKDIR /usr/
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go test -race -covermode atomic -coverprofile=profile.cov .

--- a/snapshot.go
+++ b/snapshot.go
@@ -225,8 +225,8 @@ func (c *Collection) readChunk(chunk commit.Chunk, fn func(uint64, commit.Chunk,
 
 	// Lock both the chunk and the fill list
 	c.slock.RLock(uint(chunk))
-	c.lock.RLock()
+	c.lock.Lock()
 	defer c.slock.RUnlock(uint(chunk))
-	defer c.lock.RUnlock()
+	defer c.lock.Unlock()
 	return fn(c.commits[chunk], chunk, chunk.OfBitmap(c.fill))
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -171,7 +171,7 @@ func runReplication(t *testing.T, updates, inserts, concurrency int) {
 // --------------------------- Snapshotting ----------------------------
 
 func TestSnapshot(t *testing.T) {
-	amount := 1000000
+	amount := 50000
 	buffer := bytes.NewBuffer(nil)
 	input := loadPlayers(amount)
 
@@ -181,8 +181,6 @@ func TestSnapshot(t *testing.T) {
 		for i := 0; i < amount; i++ {
 			assert.NoError(t, input.QueryAt(uint32(i), func(r Row) error {
 				r.SetEnum("name", "Roman")
-				r.SetAny("age", 15.0)
-				r.SetEnum("guild", "Ecce")
 				return nil
 			}))
 			wg.Done()

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -198,6 +198,13 @@ func TestSnapshot(t *testing.T) {
 	output := newEmpty(amount)
 	assert.NoError(t, output.Restore(buffer))
 	assert.Equal(t, amount, output.Count())
+
+	// Double restore returns no error, but does not double apply
+	buffer2 := bytes.NewBuffer(nil)
+	assert.NoError(t, input.Snapshot(buffer2))
+	assert.NotZero(t, buffer2.Len())
+	assert.Nil(t, output.Restore(buffer2))
+	assert.Equal(t, amount, output.Count())
 }
 
 func TestSnapshotFailures(t *testing.T) {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -171,7 +171,7 @@ func runReplication(t *testing.T, updates, inserts, concurrency int) {
 // --------------------------- Snapshotting ----------------------------
 
 func TestSnapshot(t *testing.T) {
-	amount := 50000
+	amount := 1000000
 	buffer := bytes.NewBuffer(nil)
 	input := loadPlayers(amount)
 
@@ -181,6 +181,8 @@ func TestSnapshot(t *testing.T) {
 		for i := 0; i < amount; i++ {
 			assert.NoError(t, input.QueryAt(uint32(i), func(r Row) error {
 				r.SetEnum("name", "Roman")
+				r.SetAny("age", 15.0)
+				r.SetEnum("guild", "Ecce")
 				return nil
 			}))
 			wg.Done()

--- a/txn.go
+++ b/txn.go
@@ -514,9 +514,11 @@ func (txn *Txn) commitUpdates(chunk commit.Chunk) (updated bool) {
 
 			// Range through all of the pending updates and apply them to the column
 			// and its associated computed columns.
+			// txn.owner.lock.Lock()
 			for _, v := range columns {
 				v.Apply(chunk, r)
 			}
+			// txn.owner.lock.Unlock()
 		})
 	}
 	return updated

--- a/txn.go
+++ b/txn.go
@@ -514,11 +514,9 @@ func (txn *Txn) commitUpdates(chunk commit.Chunk) (updated bool) {
 
 			// Range through all of the pending updates and apply them to the column
 			// and its associated computed columns.
-			txn.owner.lock.Lock()
 			for _, v := range columns {
 				v.Apply(chunk, r)
 			}
-			txn.owner.lock.Unlock()
 		})
 	}
 	return updated

--- a/txn.go
+++ b/txn.go
@@ -514,11 +514,11 @@ func (txn *Txn) commitUpdates(chunk commit.Chunk) (updated bool) {
 
 			// Range through all of the pending updates and apply them to the column
 			// and its associated computed columns.
-			// txn.owner.lock.Lock()
+			txn.owner.lock.Lock()
 			for _, v := range columns {
 				v.Apply(chunk, r)
 			}
-			// txn.owner.lock.Unlock()
+			txn.owner.lock.Unlock()
 		})
 	}
 	return updated


### PR DESCRIPTION
Hello,

I've managed to reliably replicate the race case found in multiple git workflow runs. This requires using a docker container that mocks the specifications of the Github Actions environment,  while increasing the exposure area of the edge case within TestSnapshot. 