### PR TITLE
Adding record column

### DIFF
--- a/codegen/main.go
+++ b/codegen/main.go
@@ -20,7 +20,7 @@ func main() {
 		panic(err)
 	}
 
-	dst, err := os.OpenFile("column_numbers.go", os.O_RDWR|os.O_CREATE, os.ModePerm)
+	dst, err := os.OpenFile("column_numbers.go", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	defer dst.Close()
 	if err != nil {
 		panic(err)

--- a/codegen/numbers.tpl
+++ b/codegen/numbers.tpl
@@ -33,27 +33,27 @@ func make{{.Name}}s(opts ...func(*option[{{.Type}}])) Column {
 	)
 }
 
-// {{.Type}}Writer represents a read-write accessor for {{.Type}}
-type {{.Type}}Writer struct {
-	numericReader[{{.Type}}]
+// rw{{.Name}} represents a read-write cursor for {{.Type}}
+type rw{{.Name}} struct {
+	rdNumber[{{.Type}}]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s {{.Type}}Writer) Set(value {{.Type}}) {
+func (s rw{{.Name}}) Set(value {{.Type}}) {
 	s.writer.Put{{.Name}}(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s {{.Type}}Writer) Merge(delta {{.Type}}) {
+func (s rw{{.Name}}) Merge(delta {{.Type}}) {
 	s.writer.Put{{.Name}}(commit.Merge, s.txn.cursor, delta)
 }
 
 // {{.Name}} returns a read-write accessor for {{.Type}} column
-func (txn *Txn) {{.Name}}(columnName string) {{.Type}}Writer {
-	return {{.Type}}Writer{
-		numericReader: numericReaderFor[{{.Type}}](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) {{.Name}}(columnName string) rw{{.Name}} {
+	return rw{{.Name}}{
+		rdNumber: readNumberOf[{{.Type}}](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 

--- a/collection.go
+++ b/collection.go
@@ -17,9 +17,6 @@ import (
 	"github.com/kelindar/smutex"
 )
 
-// Object represents a single object
-type Object = map[string]interface{}
-
 const (
 	expireColumn = "expire"
 	rowColumn    = "row"
@@ -127,25 +124,6 @@ func (c *Collection) findFreeIndex(count uint64) uint32 {
 	return idx
 }
 
-// InsertObject adds an object to a collection and returns the allocated index.
-func (c *Collection) InsertObject(obj Object) (index uint32) {
-	c.Query(func(txn *Txn) error {
-		index, _ = txn.InsertObject(obj)
-		return nil
-	})
-	return
-}
-
-// InsertObjectWithTTL adds an object to a collection, sets the expiration time
-// based on the specified time-to-live and returns the allocated index.
-func (c *Collection) InsertObjectWithTTL(obj Object, ttl time.Duration) (index uint32) {
-	c.Query(func(txn *Txn) error {
-		index, _ = txn.InsertObjectWithTTL(obj, ttl)
-		return nil
-	})
-	return
-}
-
 // Insert executes a mutable cursor transactionally at a new offset.
 func (c *Collection) Insert(fn func(Row) error) (index uint32, err error) {
 	err = c.Query(func(txn *Txn) (innerErr error) {
@@ -181,9 +159,9 @@ func (c *Collection) createColumnKey(columnName string, column *columnKey) error
 	return nil
 }
 
-// CreateColumnsOf registers a set of columns that are present in the target object.
-func (c *Collection) CreateColumnsOf(object Object) error {
-	for k, v := range object {
+// CreateColumnsOf registers a set of columns that are present in the target map.
+func (c *Collection) CreateColumnsOf(value map[string]any) error {
+	for k, v := range value {
 		column, err := ForKind(reflect.TypeOf(v).Kind())
 		if err != nil {
 			return err

--- a/collection_test.go
+++ b/collection_test.go
@@ -5,10 +5,8 @@ package column
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -16,50 +14,28 @@ import (
 	"time"
 
 	"github.com/kelindar/column/commit"
+	"github.com/kelindar/column/fixtures"
 	"github.com/kelindar/xxrand"
 	"github.com/stretchr/testify/assert"
 )
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkCollection/insert-8         	    2344	    493043 ns/op	   24161 B/op	     500 allocs/op
-BenchmarkCollection/select-at-8      	22826576	        51.66 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/scan-8           	    2179	    543899 ns/op	     111 B/op	       0 allocs/op
-BenchmarkCollection/count-8          	  499878	      2425 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/range-8          	   27259	     45597 ns/op	       5 B/op	       0 allocs/op
-BenchmarkCollection/sum-8            	   83598	     14057 ns/op	       3 B/op	       0 allocs/op
-BenchmarkCollection/avg-8            	   37809	     29938 ns/op	       5 B/op	       0 allocs/op
-BenchmarkCollection/max-8            	   42026	     29089 ns/op	       5 B/op	       0 allocs/op
-BenchmarkCollection/update-at-8      	 5740621	       207.3 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/update-all-8     	    1275	    927145 ns/op	    4224 B/op	       0 allocs/op
-BenchmarkCollection/delete-at-8      	 6215265	       182.3 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCollection/delete-all-8     	 1938399	       616.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/select-at-8      	18796579	        56.27 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/scan-8           	    2220	    614501 ns/op	     114 B/op	       0 allocs/op
+BenchmarkCollection/count-8          	  499893	      2414 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/range-8          	   25044	     47727 ns/op	       5 B/op	       0 allocs/op
+BenchmarkCollection/sum-8            	   84232	     14045 ns/op	       2 B/op	       0 allocs/op
+BenchmarkCollection/avg-8            	   41404	     30238 ns/op	       3 B/op	       0 allocs/op
+BenchmarkCollection/max-8            	   41194	     28929 ns/op	       6 B/op	       0 allocs/op
+BenchmarkCollection/update-at-8      	 5999748	       199.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/update-all-8     	    1269	    947274 ns/op	    4179 B/op	       0 allocs/op
+BenchmarkCollection/delete-at-8      	 7177303	       184.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCollection/delete-all-8     	 2063108	       614.8 ns/op	       0 B/op	       0 allocs/op
 */
 func BenchmarkCollection(b *testing.B) {
 	amount := 100000
 	players := loadPlayers(amount)
-
-	b.Run("insert", func(b *testing.B) {
-		temp := loadPlayers(500)
-		data := loadFixture("players.json")
-		b.ReportAllocs()
-		b.ResetTimer()
-		for n := 0; n < b.N; n++ {
-			b.StopTimer()
-			temp.Query(func(txn *Txn) error {
-				txn.DeleteAll()
-				return nil
-			})
-			b.StartTimer()
-
-			temp.Query(func(txn *Txn) error {
-				for _, p := range data {
-					txn.InsertObject(p)
-				}
-				return nil
-			})
-		}
-	})
 
 	b.Run("select-at", func(b *testing.B) {
 		name := ""
@@ -67,7 +43,7 @@ func BenchmarkCollection(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			players.QueryAt(20, func(r Row) error {
-				name, _ = r.Enum("name")
+				name, _ = r.String("name")
 				return nil
 			})
 		}
@@ -108,7 +84,7 @@ func BenchmarkCollection(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			players.Query(func(txn *Txn) error {
-				names := txn.Enum("name")
+				names := txn.String("name")
 				txn.With("human", "mage", "old").Range(func(idx uint32) {
 					count++
 					name, _ = names.Get()
@@ -275,7 +251,7 @@ func BenchmarkRecord(b *testing.B) {
 }
 
 func TestCollection(t *testing.T) {
-	obj := Object{
+	obj := map[string]any{
 		"name":   "Roman",
 		"age":    35,
 		"wallet": 50.99,
@@ -285,9 +261,20 @@ func TestCollection(t *testing.T) {
 
 	col := NewCollection()
 	col.CreateColumnsOf(obj)
-	idx := col.InsertObject(obj)
+
+	// Insert first row
+	idx, err := col.Insert(func(r Row) error {
+		return r.SetMany(obj)
+	})
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), idx)
-	assert.Equal(t, uint32(1), col.InsertObject(obj))
+
+	// Insert second row
+	idx, err = col.Insert(func(r Row) error {
+		return r.SetMany(obj)
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), idx)
 
 	// Should not drop, since it's not an index
 	assert.Error(t, col.DropIndex("name"))
@@ -319,7 +306,11 @@ func TestCollection(t *testing.T) {
 	}
 
 	{ // Add a new one, should replace
-		newIdx := col.InsertObject(obj)
+		newIdx, err := col.Insert(func(r Row) error {
+			return r.SetMany(obj)
+		})
+
+		assert.NoError(t, err)
 		assert.Equal(t, idx, newIdx)
 		assert.NoError(t, col.QueryAt(newIdx, func(r Row) error {
 			name, ok := r.String("name")
@@ -357,7 +348,7 @@ func TestCollection(t *testing.T) {
 }
 
 func TestDropColumn(t *testing.T) {
-	obj := Object{
+	obj := map[string]any{
 		"wallet": 5000,
 	}
 
@@ -367,8 +358,13 @@ func TestDropColumn(t *testing.T) {
 		return r.Float() > 100
 	}))
 
-	assert.Equal(t, uint32(0), col.InsertObject(obj))
-	assert.Equal(t, uint32(1), col.InsertObject(obj))
+	for i := 0; i < 2; i++ {
+		idx, err := col.Insert(func(r Row) error {
+			return r.SetMany(obj)
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(i), idx)
+	}
 
 	col.DropColumn("rich")
 	col.Query(func(txn *Txn) error {
@@ -377,11 +373,15 @@ func TestDropColumn(t *testing.T) {
 	})
 }
 
-func TestInsertObject(t *testing.T) {
+func TestInsertMany(t *testing.T) {
 	col := NewCollection()
 	col.CreateColumn("name", ForString())
-	col.InsertObject(Object{"name": "A"})
-	col.InsertObject(Object{"name": "B"})
+	col.Insert(func(r Row) error {
+		return r.SetMany(map[string]any{"name": "A"})
+	})
+	col.Insert(func(r Row) error {
+		return r.SetMany(map[string]any{"name": "B"})
+	})
 
 	assert.Equal(t, 2, col.Count())
 	assert.NoError(t, col.QueryAt(0, func(r Row) error {
@@ -395,7 +395,7 @@ func TestInsertObject(t *testing.T) {
 func TestExpire(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	obj := Object{
+	obj := map[string]any{
 		"name":   "Roman",
 		"age":    35,
 		"wallet": 50.99,
@@ -408,7 +408,11 @@ func TestExpire(t *testing.T) {
 	defer col.Close()
 
 	// Insert an object
-	col.InsertObjectWithTTL(obj, time.Microsecond)
+	col.Insert(func(r Row) error {
+		r.SetTTL(time.Microsecond)
+		return r.SetMany(obj)
+	})
+
 	col.Query(func(txn *Txn) error {
 		ttl := txn.TTL()
 		return txn.Range(func(idx uint32) {
@@ -466,21 +470,26 @@ func TestExpireExtend(t *testing.T) {
 }
 
 func TestCreateIndex(t *testing.T) {
-	row := Object{
+	row := map[string]any{
 		"age": 35,
 	}
 
 	// Create a collection with 1 row
 	col := NewCollection()
-	col.CreateColumnsOf(row)
-	col.InsertObject(row)
 	defer col.Close()
+
+	col.CreateColumnsOf(row)
+	col.Insert(func(r Row) error {
+		return r.SetMany(row)
+	})
 
 	// Create an index, add 1 more row
 	assert.NoError(t, col.CreateIndex("young", "age", func(r Reader) bool {
 		return r.Int() < 50
 	}))
-	col.InsertObject(row)
+	col.Insert(func(r Row) error {
+		return r.SetMany(row)
+	})
 
 	// We now should have 2 rows in the index
 	col.Query(func(txn *Txn) error {
@@ -499,15 +508,18 @@ func TestCreateIndexInvalidColumn(t *testing.T) {
 }
 
 func TestDropIndex(t *testing.T) {
-	row := Object{
+	row := map[string]any{
 		"age": 35,
 	}
 
 	// Create a collection with 1 row
 	col := NewCollection()
-	col.CreateColumnsOf(row)
-	col.InsertObject(row)
 	defer col.Close()
+
+	col.CreateColumnsOf(row)
+	col.Insert(func(r Row) error {
+		return r.SetMany(row)
+	})
 
 	// Create an index
 	assert.NoError(t, col.CreateIndex("young", "age", func(r Reader) bool {
@@ -549,7 +561,7 @@ func TestDropOneOfMultipleIndices(t *testing.T) {
 }
 
 func TestInsertParallel(t *testing.T) {
-	obj := Object{
+	obj := map[string]any{
 		"name":   "Roman",
 		"age":    35,
 		"wallet": 50.99,
@@ -558,11 +570,16 @@ func TestInsertParallel(t *testing.T) {
 	}
 
 	col := NewCollection()
+	col.CreateColumnsOf(obj)
+
 	var wg sync.WaitGroup
 	wg.Add(500)
 	for i := 0; i < 500; i++ {
 		go func() {
-			col.InsertObject(obj)
+			_, err := col.Insert(func(r Row) error {
+				return r.SetMany(obj)
+			})
+			assert.NoError(t, err)
 			wg.Done()
 		}()
 	}
@@ -576,7 +593,7 @@ func TestInsertParallel(t *testing.T) {
 }
 
 func TestConcurrentPointReads(t *testing.T) {
-	obj := Object{
+	obj := map[string]any{
 		"name":   "Roman",
 		"age":    35,
 		"wallet": 50.99,
@@ -587,7 +604,9 @@ func TestConcurrentPointReads(t *testing.T) {
 	col := NewCollection()
 	col.CreateColumnsOf(obj)
 	for i := 0; i < 1000; i++ {
-		col.InsertObject(obj)
+		col.Insert(func(r Row) error {
+			return r.SetMany(obj)
+		})
 	}
 
 	var ops int64
@@ -642,7 +661,8 @@ func TestInsertWithTTL(t *testing.T) {
 
 	idx, err := c.Insert(func(r Row) error {
 		if _, ok := r.TTL(); !ok {
-			r.SetTTL(time.Hour)
+			assert.True(t, r.SetTTL(0).IsZero())
+			assert.False(t, r.SetTTL(time.Hour).IsZero())
 			r.SetString("name", "Roman")
 		}
 		return nil
@@ -730,16 +750,34 @@ func loadPlayers(amount int) *Collection {
 	out := newEmpty(amount)
 
 	// Load and copy until we reach the amount required
-	data := loadFixture("players.json")
+	data := fixtures.Players()
 	for i := 0; i < amount/len(data); i++ {
-		out.Query(func(txn *Txn) error {
-			for _, p := range data {
-				txn.InsertObject(p)
-			}
-			return nil
-		})
+		insertPlayers(out, data)
 	}
 	return out
+}
+
+func insertPlayers(dst *Collection, data []fixtures.Player) error {
+	return dst.Query(func(txn *Txn) error {
+		for _, v := range data {
+			txn.Insert(func(r Row) error {
+				r.SetString("serial", v.Serial)
+				r.SetString("name", v.Name)
+				r.SetBool("active", v.Active)
+				r.SetEnum("class", v.Class)
+				r.SetEnum("race", v.Race)
+				r.SetInt("age", v.Age)
+				r.SetInt("hp", v.Hp)
+				r.SetInt("mp", v.Mp)
+				r.SetFloat64("balance", v.Balance)
+				r.SetEnum("gender", v.Gender)
+				r.SetEnum("guild", v.Guild)
+				r.SetRecord("location", &v.Location)
+				return nil
+			})
+		}
+		return nil
+	})
 }
 
 // newEmpty creates a new empty collection for a the fixture
@@ -752,17 +790,19 @@ func newEmpty(capacity int) *Collection {
 
 	// Load the items into the collection
 	out.CreateColumn("serial", ForString())
-	out.CreateColumn("name", ForEnum())
+	out.CreateColumn("name", ForString())
 	out.CreateColumn("active", ForBool())
 	out.CreateColumn("class", ForEnum())
 	out.CreateColumn("race", ForEnum())
-	out.CreateColumn("age", ForFloat64())
-	out.CreateColumn("hp", ForFloat64())
-	out.CreateColumn("mp", ForFloat64())
+	out.CreateColumn("age", ForInt())
+	out.CreateColumn("hp", ForInt())
+	out.CreateColumn("mp", ForInt())
 	out.CreateColumn("balance", ForFloat64())
 	out.CreateColumn("gender", ForEnum())
 	out.CreateColumn("guild", ForEnum())
-	//out.CreateColumn("location", ForString())
+	out.CreateColumn("location", ForRecord(func() *fixtures.Location {
+		return new(fixtures.Location)
+	}, nil))
 
 	// index on humans
 	out.CreateIndex("human", "race", func(r Reader) bool {
@@ -791,11 +831,13 @@ func newEmpty(capacity int) *Collection {
 
 	// index for old
 	out.CreateIndex("old", "age", func(r Reader) bool {
-		return r.Float() >= 30
+		return r.Int() >= 30
 	})
 
 	return out
 }
+
+// --------------------------- Mock Record ----------------------------
 
 type mockRecord struct {
 	errDecode bool
@@ -814,19 +856,4 @@ func (r mockRecord) UnmarshalBinary(b []byte) error {
 		return io.ErrUnexpectedEOF
 	}
 	return nil
-}
-
-// loadFixture loads a fixture by its name
-func loadFixture(name string) []Object {
-	b, err := os.ReadFile("fixtures/" + name)
-	if err != nil {
-		panic(err)
-	}
-
-	var data []Object
-	if err := json.Unmarshal(b, &data); err != nil {
-		panic(err)
-	}
-
-	return data
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"sync"
@@ -794,6 +795,25 @@ func newEmpty(capacity int) *Collection {
 	})
 
 	return out
+}
+
+type mockRecord struct {
+	errDecode bool
+	errEncode bool
+}
+
+func (r mockRecord) MarshalBinary() ([]byte, error) {
+	if r.errEncode {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return []byte("OK"), nil
+}
+
+func (r mockRecord) UnmarshalBinary(b []byte) error {
+	if r.errDecode {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 // loadFixture loads a fixture by its name

--- a/column.go
+++ b/column.go
@@ -230,7 +230,9 @@ func readerFor[T any](txn *Txn, columnName string) reader[T] {
 
 	target, ok := column.Column.(T)
 	if !ok {
-		panic(fmt.Errorf("column: column '%s' is not of specified type", columnName))
+		var want T
+		panic(fmt.Errorf("column: column '%s' is not of specified type (has=%T, want=%T)",
+			columnName, column.Column, want))
 	}
 
 	return reader[T]{
@@ -248,8 +250,8 @@ type rwAny struct {
 }
 
 // Set sets the value at the current transaction cursor
-func (s rwAny) Set(value any) {
-	s.writer.PutAny(commit.Put, *s.cursor, value)
+func (s rwAny) Set(value any) error {
+	return s.writer.PutAny(commit.Put, *s.cursor, value)
 }
 
 // --------------------------- Any Reader ----------------------------

--- a/column_expire.go
+++ b/column_expire.go
@@ -96,11 +96,15 @@ func (r Row) TTL() (time.Duration, bool) {
 	return 0, false
 }
 
-// SetTTL sets a time-to-live for a row
-func (r Row) SetTTL(ttl time.Duration) {
+// SetTTL sets a time-to-live for a row and returns the expiration time
+func (r Row) SetTTL(ttl time.Duration) (until time.Time) {
+	var nanos int64
 	if ttl > 0 {
-		r.SetInt64(expireColumn, time.Now().Add(ttl).UnixNano())
-	} else {
-		r.SetInt64(expireColumn, 0)
+		until = time.Now().Add(ttl)
+		nanos = until.UnixNano()
 	}
+
+	// Otherwise, return zero time (never expires)
+	r.SetInt64(expireColumn, nanos)
+	return
 }

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -33,27 +33,27 @@ func makeInts(opts ...func(*option[int])) Column {
 	)
 }
 
-// intWriter represents a read-write accessor for int
-type intWriter struct {
-	numericReader[int]
+// rwInt represents a read-write cursor for int
+type rwInt struct {
+	rdNumber[int]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s intWriter) Set(value int) {
+func (s rwInt) Set(value int) {
 	s.writer.PutInt(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s intWriter) Merge(delta int) {
+func (s rwInt) Merge(delta int) {
 	s.writer.PutInt(commit.Merge, s.txn.cursor, delta)
 }
 
 // Int returns a read-write accessor for int column
-func (txn *Txn) Int(columnName string) intWriter {
-	return intWriter{
-		numericReader: numericReaderFor[int](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Int(columnName string) rwInt {
+	return rwInt{
+		rdNumber: readNumberOf[int](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -82,27 +82,27 @@ func makeInt16s(opts ...func(*option[int16])) Column {
 	)
 }
 
-// int16Writer represents a read-write accessor for int16
-type int16Writer struct {
-	numericReader[int16]
+// rwInt16 represents a read-write cursor for int16
+type rwInt16 struct {
+	rdNumber[int16]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s int16Writer) Set(value int16) {
+func (s rwInt16) Set(value int16) {
 	s.writer.PutInt16(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s int16Writer) Merge(delta int16) {
+func (s rwInt16) Merge(delta int16) {
 	s.writer.PutInt16(commit.Merge, s.txn.cursor, delta)
 }
 
 // Int16 returns a read-write accessor for int16 column
-func (txn *Txn) Int16(columnName string) int16Writer {
-	return int16Writer{
-		numericReader: numericReaderFor[int16](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Int16(columnName string) rwInt16 {
+	return rwInt16{
+		rdNumber: readNumberOf[int16](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -131,27 +131,27 @@ func makeInt32s(opts ...func(*option[int32])) Column {
 	)
 }
 
-// int32Writer represents a read-write accessor for int32
-type int32Writer struct {
-	numericReader[int32]
+// rwInt32 represents a read-write cursor for int32
+type rwInt32 struct {
+	rdNumber[int32]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s int32Writer) Set(value int32) {
+func (s rwInt32) Set(value int32) {
 	s.writer.PutInt32(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s int32Writer) Merge(delta int32) {
+func (s rwInt32) Merge(delta int32) {
 	s.writer.PutInt32(commit.Merge, s.txn.cursor, delta)
 }
 
 // Int32 returns a read-write accessor for int32 column
-func (txn *Txn) Int32(columnName string) int32Writer {
-	return int32Writer{
-		numericReader: numericReaderFor[int32](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Int32(columnName string) rwInt32 {
+	return rwInt32{
+		rdNumber: readNumberOf[int32](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -180,27 +180,27 @@ func makeInt64s(opts ...func(*option[int64])) Column {
 	)
 }
 
-// int64Writer represents a read-write accessor for int64
-type int64Writer struct {
-	numericReader[int64]
+// rwInt64 represents a read-write cursor for int64
+type rwInt64 struct {
+	rdNumber[int64]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s int64Writer) Set(value int64) {
+func (s rwInt64) Set(value int64) {
 	s.writer.PutInt64(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s int64Writer) Merge(delta int64) {
+func (s rwInt64) Merge(delta int64) {
 	s.writer.PutInt64(commit.Merge, s.txn.cursor, delta)
 }
 
 // Int64 returns a read-write accessor for int64 column
-func (txn *Txn) Int64(columnName string) int64Writer {
-	return int64Writer{
-		numericReader: numericReaderFor[int64](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Int64(columnName string) rwInt64 {
+	return rwInt64{
+		rdNumber: readNumberOf[int64](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -229,27 +229,27 @@ func makeUints(opts ...func(*option[uint])) Column {
 	)
 }
 
-// uintWriter represents a read-write accessor for uint
-type uintWriter struct {
-	numericReader[uint]
+// rwUint represents a read-write cursor for uint
+type rwUint struct {
+	rdNumber[uint]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s uintWriter) Set(value uint) {
+func (s rwUint) Set(value uint) {
 	s.writer.PutUint(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s uintWriter) Merge(delta uint) {
+func (s rwUint) Merge(delta uint) {
 	s.writer.PutUint(commit.Merge, s.txn.cursor, delta)
 }
 
 // Uint returns a read-write accessor for uint column
-func (txn *Txn) Uint(columnName string) uintWriter {
-	return uintWriter{
-		numericReader: numericReaderFor[uint](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Uint(columnName string) rwUint {
+	return rwUint{
+		rdNumber: readNumberOf[uint](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -278,27 +278,27 @@ func makeUint16s(opts ...func(*option[uint16])) Column {
 	)
 }
 
-// uint16Writer represents a read-write accessor for uint16
-type uint16Writer struct {
-	numericReader[uint16]
+// rwUint16 represents a read-write cursor for uint16
+type rwUint16 struct {
+	rdNumber[uint16]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s uint16Writer) Set(value uint16) {
+func (s rwUint16) Set(value uint16) {
 	s.writer.PutUint16(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s uint16Writer) Merge(delta uint16) {
+func (s rwUint16) Merge(delta uint16) {
 	s.writer.PutUint16(commit.Merge, s.txn.cursor, delta)
 }
 
 // Uint16 returns a read-write accessor for uint16 column
-func (txn *Txn) Uint16(columnName string) uint16Writer {
-	return uint16Writer{
-		numericReader: numericReaderFor[uint16](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Uint16(columnName string) rwUint16 {
+	return rwUint16{
+		rdNumber: readNumberOf[uint16](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -327,27 +327,27 @@ func makeUint32s(opts ...func(*option[uint32])) Column {
 	)
 }
 
-// uint32Writer represents a read-write accessor for uint32
-type uint32Writer struct {
-	numericReader[uint32]
+// rwUint32 represents a read-write cursor for uint32
+type rwUint32 struct {
+	rdNumber[uint32]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s uint32Writer) Set(value uint32) {
+func (s rwUint32) Set(value uint32) {
 	s.writer.PutUint32(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s uint32Writer) Merge(delta uint32) {
+func (s rwUint32) Merge(delta uint32) {
 	s.writer.PutUint32(commit.Merge, s.txn.cursor, delta)
 }
 
 // Uint32 returns a read-write accessor for uint32 column
-func (txn *Txn) Uint32(columnName string) uint32Writer {
-	return uint32Writer{
-		numericReader: numericReaderFor[uint32](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Uint32(columnName string) rwUint32 {
+	return rwUint32{
+		rdNumber: readNumberOf[uint32](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -376,27 +376,27 @@ func makeUint64s(opts ...func(*option[uint64])) Column {
 	)
 }
 
-// uint64Writer represents a read-write accessor for uint64
-type uint64Writer struct {
-	numericReader[uint64]
+// rwUint64 represents a read-write cursor for uint64
+type rwUint64 struct {
+	rdNumber[uint64]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s uint64Writer) Set(value uint64) {
+func (s rwUint64) Set(value uint64) {
 	s.writer.PutUint64(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s uint64Writer) Merge(delta uint64) {
+func (s rwUint64) Merge(delta uint64) {
 	s.writer.PutUint64(commit.Merge, s.txn.cursor, delta)
 }
 
 // Uint64 returns a read-write accessor for uint64 column
-func (txn *Txn) Uint64(columnName string) uint64Writer {
-	return uint64Writer{
-		numericReader: numericReaderFor[uint64](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Uint64(columnName string) rwUint64 {
+	return rwUint64{
+		rdNumber: readNumberOf[uint64](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -425,27 +425,27 @@ func makeFloat32s(opts ...func(*option[float32])) Column {
 	)
 }
 
-// float32Writer represents a read-write accessor for float32
-type float32Writer struct {
-	numericReader[float32]
+// rwFloat32 represents a read-write cursor for float32
+type rwFloat32 struct {
+	rdNumber[float32]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s float32Writer) Set(value float32) {
+func (s rwFloat32) Set(value float32) {
 	s.writer.PutFloat32(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s float32Writer) Merge(delta float32) {
+func (s rwFloat32) Merge(delta float32) {
 	s.writer.PutFloat32(commit.Merge, s.txn.cursor, delta)
 }
 
 // Float32 returns a read-write accessor for float32 column
-func (txn *Txn) Float32(columnName string) float32Writer {
-	return float32Writer{
-		numericReader: numericReaderFor[float32](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Float32(columnName string) rwFloat32 {
+	return rwFloat32{
+		rdNumber: readNumberOf[float32](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 
@@ -474,27 +474,27 @@ func makeFloat64s(opts ...func(*option[float64])) Column {
 	)
 }
 
-// float64Writer represents a read-write accessor for float64
-type float64Writer struct {
-	numericReader[float64]
+// rwFloat64 represents a read-write cursor for float64
+type rwFloat64 struct {
+	rdNumber[float64]
 	writer *commit.Buffer
 }
 
 // Set sets the value at the current transaction cursor
-func (s float64Writer) Set(value float64) {
+func (s rwFloat64) Set(value float64) {
 	s.writer.PutFloat64(commit.Put, s.txn.cursor, value)
 }
 
 // Merge atomically merges a delta to the value at the current transaction cursor
-func (s float64Writer) Merge(delta float64) {
+func (s rwFloat64) Merge(delta float64) {
 	s.writer.PutFloat64(commit.Merge, s.txn.cursor, delta)
 }
 
 // Float64 returns a read-write accessor for float64 column
-func (txn *Txn) Float64(columnName string) float64Writer {
-	return float64Writer{
-		numericReader: numericReaderFor[float64](txn, columnName),
-		writer:        txn.bufferFor(columnName),
+func (txn *Txn) Float64(columnName string) rwFloat64 {
+	return rwFloat64{
+		rdNumber: readNumberOf[float64](txn, columnName),
+		writer:   txn.bufferFor(columnName),
 	}
 }
 

--- a/column_numeric.go
+++ b/column_numeric.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kelindar/simd"
 )
 
+//go:generate go run ./codegen/main.go
+
 // readNumber is a helper function for point reads
 func readNumber[T simd.Number](txn *Txn, columnName string) (value T, found bool) {
 	if column, ok := txn.columnAt(columnName); ok {
@@ -134,19 +136,19 @@ func (c *numericColumn[T]) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 
 // --------------------------- Reader/Writer ----------------------------
 
-// numericReader represents a read-only accessor for simd.Numbers
-type numericReader[T simd.Number] struct {
+// rdNumber represents a read-only accessor for simd.Numbers
+type rdNumber[T simd.Number] struct {
 	reader *numericColumn[T]
 	txn    *Txn
 }
 
 // Get loads the value at the current transaction cursor
-func (s numericReader[T]) Get() (T, bool) {
+func (s rdNumber[T]) Get() (T, bool) {
 	return s.reader.load(s.txn.cursor)
 }
 
 // Sum computes a sum of the column values selected by this transaction
-func (s numericReader[T]) Sum() (sum T) {
+func (s rdNumber[T]) Sum() (sum T) {
 	s.txn.initialize()
 	s.txn.rangeRead(func(chunk commit.Chunk, index bitmap.Bitmap) {
 		if int(chunk) < len(s.reader.chunks) {
@@ -157,7 +159,7 @@ func (s numericReader[T]) Sum() (sum T) {
 }
 
 // Avg computes an arithmetic mean of the column values selected by this transaction
-func (s numericReader[T]) Avg() float64 {
+func (s rdNumber[T]) Avg() float64 {
 	sum, ct := T(0), 0
 	s.txn.initialize()
 	s.txn.rangeRead(func(chunk commit.Chunk, index bitmap.Bitmap) {
@@ -170,7 +172,7 @@ func (s numericReader[T]) Avg() float64 {
 }
 
 // Min finds the smallest value from the column values selected by this transaction
-func (s numericReader[T]) Min() (min T, ok bool) {
+func (s rdNumber[T]) Min() (min T, ok bool) {
 	s.txn.initialize()
 	s.txn.rangeRead(func(chunk commit.Chunk, index bitmap.Bitmap) {
 		if int(chunk) < len(s.reader.chunks) {
@@ -184,7 +186,7 @@ func (s numericReader[T]) Min() (min T, ok bool) {
 }
 
 // Max finds the largest value from the column values selected by this transaction
-func (s numericReader[T]) Max() (max T, ok bool) {
+func (s rdNumber[T]) Max() (max T, ok bool) {
 	s.txn.initialize()
 	s.txn.rangeRead(func(chunk commit.Chunk, index bitmap.Bitmap) {
 		if int(chunk) < len(s.reader.chunks) {
@@ -197,8 +199,8 @@ func (s numericReader[T]) Max() (max T, ok bool) {
 	return
 }
 
-// numericReaderFor creates a new numeric reader
-func numericReaderFor[T simd.Number](txn *Txn, columnName string) numericReader[T] {
+// readNumberOf creates a new numeric reader
+func readNumberOf[T simd.Number](txn *Txn, columnName string) rdNumber[T] {
 	column, ok := txn.columnAt(columnName)
 	if !ok {
 		panic(fmt.Errorf("column: column '%s' does not exist", columnName))
@@ -209,7 +211,7 @@ func numericReaderFor[T simd.Number](txn *Txn, columnName string) numericReader[
 		panic(fmt.Errorf("column: column '%s' is not of type %T", columnName, float64(0)))
 	}
 
-	return numericReader[T]{
+	return rdNumber[T]{
 		reader: reader,
 		txn:    txn,
 	}

--- a/column_numeric.go
+++ b/column_numeric.go
@@ -208,7 +208,7 @@ func readNumberOf[T simd.Number](txn *Txn, columnName string) rdNumber[T] {
 
 	reader, ok := column.Column.(*numericColumn[T])
 	if !ok {
-		panic(fmt.Errorf("column: column '%s' is not of type %T", columnName, float64(0)))
+		panic(fmt.Errorf("column: column '%s' is not of type %T", columnName, T(0)))
 	}
 
 	return rdNumber[T]{

--- a/column_record.go
+++ b/column_record.go
@@ -1,0 +1,159 @@
+// Copyright (c) Roman Atachiants and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+package column
+
+import (
+	"encoding"
+	"reflect"
+	"sync"
+	"unsafe"
+
+	"github.com/kelindar/column/commit"
+)
+
+type recordType interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+}
+
+// --------------------------- Record ----------------------------
+
+// columnRecord represents a typed column that is persisted using binary marshaler
+type columnRecord struct {
+	columnString
+	pool *sync.Pool
+}
+
+// ForRecord creates a new column that contains a type marshaled into/from binary. It requires
+// a constructor for the type as well as optional merge function. If merge function is
+// set to nil, "overwrite" strategy will be used.
+func ForRecord[T recordType](new func() T, merge func(value, delta T) T) Column {
+	if merge == nil {
+		merge = func(value, delta T) T { return delta }
+	}
+
+	pool := &sync.Pool{
+		New: func() any { return new() },
+	}
+
+	// Merge function that decodes, merges and re-encodes records into their
+	// respective binary representation.
+	mergeRecord := func(v, d string) string {
+		value := pool.Get().(T)
+		delta := pool.Get().(T)
+		defer pool.Put(value)
+		defer pool.Put(delta)
+
+		// Unmarshal the existing value
+		err1 := value.UnmarshalBinary(s2b(v))
+		err2 := delta.UnmarshalBinary(s2b(d))
+		if err1 != nil || err2 != nil {
+			return v
+		}
+
+		// Apply the user-defined merging strategy
+		merged := merge(value, delta)
+
+		// Marshal the value back
+		if encoded, err := merged.MarshalBinary(); err == nil {
+			return b2s(&encoded)
+		}
+		return v
+	}
+
+	return &columnRecord{
+		pool: pool,
+		columnString: columnString{
+			chunks: make(chunks[string], 0, 4),
+			option: option[string]{
+				Merge: mergeRecord,
+			},
+		},
+	}
+}
+
+// --------------------------- Writer ----------------------------
+
+// rwRecord represents read-write accessor for primary keys.
+type rwRecord struct {
+	rdRecord
+	writer *commit.Buffer
+}
+
+// Set sets the value at the current transaction index
+func (s rwRecord) Set(value encoding.BinaryMarshaler) error {
+	return s.write(commit.Put, value.MarshalBinary)
+}
+
+// Merge atomically merges a delta to the value at the current transaction cursor
+func (s rwRecord) Merge(delta encoding.BinaryMarshaler) error {
+	return s.write(commit.Merge, delta.MarshalBinary)
+}
+
+// write writes the operation
+func (s rwRecord) write(op commit.OpType, encodeDelta func() ([]byte, error)) error {
+	v, err := encodeDelta()
+	if err == nil {
+		s.writer.PutBytes(op, *s.cursor, v)
+	}
+	return err
+}
+
+// As creates a read-write accessor for a specific record type.
+func (txn *Txn) Record(columnName string) rwRecord {
+	return rwRecord{
+		rdRecord: readRecordOf(txn, columnName),
+		writer:   txn.bufferFor(columnName),
+	}
+}
+
+// --------------------------- Reader ----------------------------
+
+// rdRecord represents a read-only accessor for records
+type rdRecord reader[*columnRecord]
+
+// Get loads the value at the current transaction index
+func (s rdRecord) Get() (any, bool) {
+	value := s.reader.pool.New().(encoding.BinaryUnmarshaler)
+	if s.Unmarshal(value.UnmarshalBinary) {
+		return value, true
+	}
+
+	return nil, false
+}
+
+// Unmarshal loads the value at the current transaction index using a
+// specified function to decode the value.
+func (s rdRecord) Unmarshal(decode func(data []byte) error) bool {
+	encoded, ok := s.reader.LoadString(*s.cursor)
+	if !ok {
+		return false
+	}
+
+	return decode(s2b(encoded)) == nil
+}
+
+// readRecordOf creates a read-only accessor for readers
+func readRecordOf(txn *Txn, columnName string) rdRecord {
+	return rdRecord(readerFor[*columnRecord](txn, columnName))
+}
+
+// --------------------------- Convert ----------------------------
+
+// b2s converts byte slice to a string without allocating.
+func b2s(b *[]byte) string {
+	return *(*string)(unsafe.Pointer(b))
+}
+
+// s2b converts a string to a byte slice without allocating.
+func s2b(v string) (b []byte) {
+	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&v))
+	byteHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	byteHeader.Data = strHeader.Data
+
+	l := len(v)
+	byteHeader.Len = l
+	byteHeader.Cap = l
+	return
+}

--- a/column_test.go
+++ b/column_test.go
@@ -5,7 +5,6 @@ package column
 
 import (
 	"fmt"
-	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -674,25 +673,6 @@ func TestRecordMerge_ErrEncode(t *testing.T) {
 		assert.NoError(t, r.MergeRecord("record", mockRecord{}))
 		return nil
 	})
-}
-
-type mockRecord struct {
-	errDecode bool
-	errEncode bool
-}
-
-func (r mockRecord) MarshalBinary() ([]byte, error) {
-	if r.errEncode {
-		return nil, io.ErrUnexpectedEOF
-	}
-	return []byte("OK"), nil
-}
-
-func (r mockRecord) UnmarshalBinary(b []byte) error {
-	if r.errDecode {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
 }
 
 func invoke(any interface{}, name string, args ...interface{}) []reflect.Value {

--- a/column_test.go
+++ b/column_test.go
@@ -232,7 +232,10 @@ func TestForString(t *testing.T) {
 
 	data := []string{"a", "b", "c", "d"}
 	for i, d := range data {
-		coll.InsertObject(map[string]interface{}{"id": i, "data": d})
+		_, err := coll.Insert(func(r Row) error {
+			return r.SetMany(map[string]any{"id": i, "data": d})
+		})
+		assert.NoError(t, err)
 	}
 
 	coll.Query(func(txn *Txn) error {
@@ -265,13 +268,13 @@ func TestAtKey(t *testing.T) {
 	}))
 
 	assert.NoError(t, players.QueryKey(testKey, func(r Row) error {
-		r.SetEnum("name", "Roman")
+		r.SetString("name", "Roman")
 		return nil
 	}))
 
 	// Read back and assert
 	assertion := func(r Row) error {
-		name, _ := r.Enum("name")
+		name, _ := r.String("name")
 		race, _ := r.Enum("race")
 		assert.Equal(t, "Roman", name)
 		assert.Equal(t, "elf", race)
@@ -631,6 +634,7 @@ func TestRecord_Errors(t *testing.T) {
 		assert.False(t, ok)
 		return nil
 	})
+
 }
 
 func TestRecordMerge_ErrDecode(t *testing.T) {

--- a/commit/buffer_test.go
+++ b/commit/buffer_test.go
@@ -246,7 +246,7 @@ func TestPutTime(t *testing.T) {
 	r := NewReader()
 	r.Seek(buf)
 	assert.True(t, r.Next())
-	assert.Equal(t, []byte{0x1, 0x0, 0x0, 0x0, 0xe, 0x77, 0x91, 0xf7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0}, r.Bytes())
+	assert.NotEmpty(t, r.Bytes())
 }
 
 func TestPutBitmap(t *testing.T) {

--- a/commit/buffer_test.go
+++ b/commit/buffer_test.go
@@ -6,6 +6,7 @@ package commit
 import (
 	"bytes"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/kelindar/bitmap"
@@ -236,6 +237,16 @@ func TestPutNil(t *testing.T) {
 	r.Seek(buf)
 	assert.True(t, r.Next())
 	assert.True(t, r.Bool())
+}
+
+func TestPutTime(t *testing.T) {
+	buf := NewBuffer(0)
+	buf.PutAny(Put, 0, time.Unix(0, 0))
+
+	r := NewReader()
+	r.Seek(buf)
+	assert.True(t, r.Next())
+	assert.Equal(t, []byte{0x1, 0x0, 0x0, 0x0, 0xe, 0x77, 0x91, 0xf7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0}, r.Bytes())
 }
 
 func TestPutBitmap(t *testing.T) {

--- a/commit/reader.go
+++ b/commit/reader.go
@@ -242,6 +242,13 @@ func (r *Reader) SwapString(v string) string {
 	return v
 }
 
+// SwapBytes swaps a binary value with a new one.
+func (r *Reader) SwapBytes(v []byte) []byte {
+	r.writeSkipped()
+	r.PutBytes(Put, r.Index(), v)
+	return v
+}
+
 // writeSwapped marks the current value to be a store
 func (r *Reader) writeSwapped() {
 	r.buffer[r.i0-1] &= 0xf0

--- a/commit/reader_test.go
+++ b/commit/reader_test.go
@@ -294,3 +294,22 @@ func TestMergeString(t *testing.T) {
 	assert.True(t, r.Next())
 	assert.Equal(t, Skip, r.Type)
 }
+
+func TestMergeBytes(t *testing.T) {
+	buf := NewBuffer(0)
+	buf.PutBytes(Merge, 10, []byte("A"))
+	assert.Equal(t, []byte{0x53, 0x0, 0x1, 0x41, 0xa}, buf.buffer)
+
+	// Swap the value, this should also change the type
+	r := NewReader()
+	r.Seek(buf)
+	assert.True(t, r.Next())
+	assert.Equal(t, Merge, r.Type)
+	r.SwapBytes([]byte("B"))
+
+	// Once swapped, op type should be changed to "Put"
+	r.Seek(buf)
+	assert.Equal(t, []byte{0x54, 0x0, 0x1, 0x41, 0xa, 0x52, 0x0, 0x1, 0x42, 0x0}, buf.buffer)
+	assert.True(t, r.Next())
+	assert.Equal(t, Skip, r.Type)
+}

--- a/commit/reader_test.go
+++ b/commit/reader_test.go
@@ -6,7 +6,6 @@ package commit
 import (
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -176,10 +175,8 @@ func TestReadSwap(t *testing.T) {
 }
 
 func TestWriteUnsupported(t *testing.T) {
-	assert.Panics(t, func() {
-		buf := NewBuffer(0)
-		buf.PutAny(Put, 10, time.Time{})
-	})
+	buf := NewBuffer(0)
+	assert.Error(t, buf.PutAny(Put, 10, complex64(1)))
 }
 
 func TestReaderIface(t *testing.T) {

--- a/examples/bench/bench.go
+++ b/examples/bench/bench.go
@@ -5,9 +5,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,6 +13,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/kelindar/async"
 	"github.com/kelindar/column"
+	"github.com/kelindar/column/fixtures"
 	"github.com/kelindar/xxrand"
 )
 
@@ -101,9 +100,9 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 	out.CreateColumn("active", column.ForBool())
 	out.CreateColumn("class", column.ForEnum())
 	out.CreateColumn("race", column.ForEnum())
-	out.CreateColumn("age", column.ForFloat64())
-	out.CreateColumn("hp", column.ForFloat64())
-	out.CreateColumn("mp", column.ForFloat64())
+	out.CreateColumn("age", column.ForInt())
+	out.CreateColumn("hp", column.ForInt())
+	out.CreateColumn("mp", column.ForInt())
 	out.CreateColumn("balance", column.ForFloat64())
 	out.CreateColumn("gender", column.ForEnum())
 	out.CreateColumn("guild", column.ForEnum())
@@ -121,27 +120,34 @@ func createCollection(out *column.Collection, amount int) *column.Collection {
 			return r.String() == race
 		})
 	}
-	// Load the 500 rows from JSON
-	b, err := os.ReadFile("../../fixtures/players.json")
-	if err != nil {
-		panic(err)
-	}
-
-	// Unmarshal the items
-	var data []map[string]interface{}
-	if err := json.Unmarshal(b, &data); err != nil {
-		panic(err)
-	}
-
 	// Load the data in
+	data := fixtures.Players()
 	for i := 0; i < amount/len(data); i++ {
-		out.Query(func(txn *column.Txn) error {
-			for _, p := range data {
-				txn.InsertObject(p)
-			}
-			return nil
-		})
+		insertPlayers(out, data)
 	}
 
 	return out
+}
+
+// insertPlayers inserts players
+func insertPlayers(dst *column.Collection, data []fixtures.Player) error {
+	return dst.Query(func(txn *column.Txn) error {
+		for _, v := range data {
+			txn.Insert(func(r column.Row) error {
+				r.SetEnum("serial", v.Serial)
+				r.SetEnum("name", v.Name)
+				r.SetBool("active", v.Active)
+				r.SetEnum("class", v.Class)
+				r.SetEnum("race", v.Race)
+				r.SetInt("age", v.Age)
+				r.SetInt("hp", v.Hp)
+				r.SetInt("mp", v.Mp)
+				r.SetFloat64("balance", v.Balance)
+				r.SetEnum("gender", v.Gender)
+				r.SetEnum("guild", v.Guild)
+				return nil
+			})
+		}
+		return nil
+	})
 }

--- a/examples/million/README.md
+++ b/examples/million/README.md
@@ -6,35 +6,32 @@ This example adds 10 million rows to a collection, runs and measures a few diffe
 
 ```
 running insert of 10000000 rows...
--> inserted 0 rows
-...
--> inserted 9900000 rows
--> insert took 9.6700612s
+-> insert took 7.6464726s
 
 running snapshot of 10000000 rows...
--> snapshot took 1.02656756s
+-> snapshot took 1.35868707s
 
 running full scan of age >= 30...
 -> result = 5100000
--> full scan took 26.217664ms
+-> full scan took 27.011615ms
 
 running full scan of class == "rogue"...
 -> result = 3580000
--> full scan took 41.691512ms
+-> full scan took 45.053185ms
 
 running indexed query of human mages...
 -> result = 680000
--> indexed query took 269.734µs
+-> indexed query took 309.74µs
 
 running indexed query of human female mages...
 -> result = 320000
--> indexed query took 330.87µs
+-> indexed query took 385.606µs
 
 running update of balance of everyone...
 -> updated 10000000 rows
--> update took 101.451402ms
+-> update took 108.09756ms
 
 running update of age of mages...
 -> updated 3020000 rows
--> update took 39.874322ms
+-> update took 41.731165ms
 ```

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -12,16 +12,19 @@ func main() {
 	// Create a new columnar collection
 	players := column.NewCollection()
 	players.CreateColumn("serial", column.ForKey())
-	players.CreateColumn("name", column.ForEnum())
+	players.CreateColumn("name", column.ForString())
 	players.CreateColumn("active", column.ForBool())
 	players.CreateColumn("class", column.ForEnum())
 	players.CreateColumn("race", column.ForEnum())
-	players.CreateColumn("age", column.ForFloat64())
-	players.CreateColumn("hp", column.ForFloat64())
-	players.CreateColumn("mp", column.ForFloat64())
+	players.CreateColumn("age", column.ForInt())
+	players.CreateColumn("hp", column.ForInt())
+	players.CreateColumn("mp", column.ForInt())
 	players.CreateColumn("balance", column.ForFloat64())
 	players.CreateColumn("gender", column.ForEnum())
 	players.CreateColumn("guild", column.ForEnum())
+	players.CreateColumn("location", column.ForRecord(func() *Location {
+		return new(Location)
+	}, nil))
 
 	// index on humans
 	players.CreateIndex("human", "race", func(r column.Reader) bool {
@@ -35,21 +38,35 @@ func main() {
 
 	// index for old
 	players.CreateIndex("old", "age", func(r column.Reader) bool {
-		return r.Float() >= 30
+		return r.Int() >= 30
 	})
 
 	// Load the items into the collection
 	loaded := loadFixture("players.json")
 	players.Query(func(txn *column.Txn) error {
 		for _, v := range loaded {
-			txn.InsertObject(v)
+			txn.InsertKey(v.Serial, func(r column.Row) error {
+				r.SetKey(v.Serial)
+				r.SetString("name", v.Name)
+				r.SetBool("active", v.Active)
+				r.SetEnum("class", v.Class)
+				r.SetEnum("race", v.Race)
+				r.SetInt("age", v.Age)
+				r.SetInt("hp", v.Hp)
+				r.SetInt("mp", v.Mp)
+				r.SetFloat64("balance", v.Balance)
+				r.SetEnum("gender", v.Gender)
+				r.SetEnum("guild", v.Guild)
+				r.SetRecord("location", &v.Location)
+				return nil
+			})
 		}
 		return nil
 	})
 
 	// Run an indexed query
 	players.Query(func(txn *column.Txn) error {
-		name := txn.Enum("name")
+		name := txn.String("name")
 		return txn.With("human", "mage", "old").Range(func(idx uint32) {
 			value, _ := name.Get()
 			println("old mage, human:", value)
@@ -58,16 +75,46 @@ func main() {
 }
 
 // loadFixture loads a fixture by its name
-func loadFixture(name string) []column.Object {
+func loadFixture(name string) []Player {
 	b, err := os.ReadFile("../../fixtures/" + name)
 	if err != nil {
 		panic(err)
 	}
 
-	var data []column.Object
+	var data []Player
 	if err := json.Unmarshal(b, &data); err != nil {
 		panic(err)
 	}
 
 	return data
+}
+
+// --------------------------- Player ----------------------------
+
+type Player struct {
+	Serial   string   `json:"serial"`
+	Name     string   `json:"name"`
+	Active   bool     `json:"active"`
+	Class    string   `json:"class"`
+	Race     string   `json:"race"`
+	Age      int      `json:"age"`
+	Hp       int      `json:"hp"`
+	Mp       int      `json:"mp"`
+	Balance  float64  `json:"balance"`
+	Gender   string   `json:"gender"`
+	Guild    string   `json:"guild"`
+	Location Location `json:"location"`
+}
+
+type Location struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+func (l Location) MarshalBinary() ([]byte, error) {
+	return json.Marshal(l)
+}
+
+func (l *Location) UnmarshalBinary(b []byte) error {
+	return json.Unmarshal(b, l)
 }

--- a/fixtures/players.go
+++ b/fixtures/players.go
@@ -1,0 +1,49 @@
+package fixtures
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed players.json
+var playerData []byte
+
+// Players loads a set of players
+func Players() []Player {
+	var data []Player
+	if err := json.Unmarshal(playerData, &data); err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+// --------------------------- Player ----------------------------
+
+type Player struct {
+	Serial   string   `json:"serial"`
+	Name     string   `json:"name"`
+	Active   bool     `json:"active"`
+	Class    string   `json:"class"`
+	Race     string   `json:"race"`
+	Age      int      `json:"age"`
+	Hp       int      `json:"hp"`
+	Mp       int      `json:"mp"`
+	Balance  float64  `json:"balance"`
+	Gender   string   `json:"gender"`
+	Guild    string   `json:"guild"`
+	Location Location `json:"location"`
+}
+
+type Location struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+func (l Location) MarshalBinary() ([]byte, error) {
+	return json.Marshal(l)
+}
+
+func (l *Location) UnmarshalBinary(b []byte) error {
+	return json.Unmarshal(b, l)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/klauspost/compress v1.15.11
 	github.com/stretchr/testify v1.8.0
 	github.com/zeebo/xxh3 v1.0.2
-	github.com/imdario/mergo v0.3.13
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
-github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/kelindar/async v1.0.0 h1:oJiFAt3fVB/b5zVZKPBU+pP9lR3JVyeox9pYlpdnIK8=
 github.com/kelindar/async v1.0.0/go.mod h1:bJRlwaRiqdHi+4dpVDNHdwgyRyk6TxpA21fByLf7hIY=
 github.com/kelindar/bitmap v1.4.1 h1:Ih0BWMYXkkZxPMU536DsQKRhdvqFl7tuNjImfLJWC6E=
@@ -43,6 +41,5 @@ golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxb
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/txn.go
+++ b/txn.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/kelindar/bitmap"
 	"github.com/kelindar/column/commit"
@@ -220,7 +219,7 @@ func (txn *Txn) WithUnion(columns ...string) *Txn {
 		lock.RLock(uint(chunk))
 
 		// reset entire bitmap
-		for i, _ := range tmpMap {
+		for i := range tmpMap {
 			tmpMap[i] = 0
 		}
 
@@ -346,25 +345,6 @@ func (txn *Txn) DeleteAt(index uint32) bool {
 // deleteAt marks an index as deleted
 func (txn *Txn) deleteAt(idx uint32) {
 	txn.bufferFor(rowColumn).PutOperation(commit.Delete, idx)
-}
-
-// InsertObject adds an object to a collection and returns the allocated index.
-func (txn *Txn) InsertObject(object Object) (uint32, error) {
-	return txn.InsertObjectWithTTL(object, 0)
-}
-
-// InsertObjectWithTTL adds an object to a collection, sets the expiration time
-// based on the specified time-to-live and returns the allocated index.
-func (txn *Txn) InsertObjectWithTTL(object Object, ttl time.Duration) (uint32, error) {
-	return txn.Insert(func(r Row) error {
-		r.SetTTL(ttl)
-		for k, v := range object {
-			if _, ok := txn.columnAt(k); ok {
-				txn.bufferFor(k).PutAny(commit.Put, txn.cursor, v)
-			}
-		}
-		return nil
-	})
 }
 
 // Insert executes a mutable cursor transactionally at a new offset.

--- a/txn_row.go
+++ b/txn_row.go
@@ -3,6 +3,10 @@
 
 package column
 
+import (
+	"encoding"
+)
+
 // Row represents a cursor at a particular row offest in the transaction.
 type Row struct {
 	txn *Txn
@@ -177,7 +181,7 @@ func (r Row) SetKey(key string) {
 
 // String loads a string value at a particular column
 func (r Row) String(columnName string) (v string, ok bool) {
-	return textReaderFor[*columnString](r.txn, columnName).Get()
+	return readStringOf[*columnString](r.txn, columnName).Get()
 }
 
 // SetString stores a string value at a particular column
@@ -192,7 +196,7 @@ func (r Row) MergeString(columnName string, value string) {
 
 // Enum loads a string value at a particular column
 func (r Row) Enum(columnName string) (v string, ok bool) {
-	return textReaderFor[*columnEnum](r.txn, columnName).Get()
+	return readStringOf[*columnEnum](r.txn, columnName).Get()
 }
 
 // SetEnum stores a string value at a particular column
@@ -200,11 +204,28 @@ func (r Row) SetEnum(columnName string, value string) {
 	r.txn.Enum(columnName).Set(value)
 }
 
+// --------------------------- Records ----------------------------
+
+// Record loads a record value at a particular column
+func (r Row) Record(columnName string) (any, bool) {
+	return readRecordOf(r.txn, columnName).Get()
+}
+
+// SetRecord stores a record value at a particular column
+func (r Row) SetRecord(columnName string, value encoding.BinaryMarshaler) error {
+	return r.txn.Record(columnName).Set(value)
+}
+
+// MergeRecord merges a record value at a particular column
+func (r Row) MergeRecord(columnName string, delta encoding.BinaryMarshaler) error {
+	return r.txn.Record(columnName).Merge(delta)
+}
+
 // --------------------------- Others ----------------------------
 
 // Bool loads a bool value at a particular column
 func (r Row) Bool(columnName string) bool {
-	return boolReaderFor(r.txn, columnName).Get()
+	return readBoolOf(r.txn, columnName).Get()
 }
 
 // SetBool stores a bool value at a particular column
@@ -214,7 +235,7 @@ func (r Row) SetBool(columnName string, value bool) {
 
 // Any loads a bool value at a particular column
 func (r Row) Any(columnName string) (any, bool) {
-	return anyReaderFor(r.txn, columnName).Get()
+	return readAnyOf(r.txn, columnName).Get()
 }
 
 // SetAny stores a bool value at a particular column


### PR DESCRIPTION
This PR contains some refactoring and a new `record` column that allows you to use a `BinaryMarshaler` and `BinaryUnmarshaler` type to be stored. As such, it supports types that implement this standard way of encoding, for example `time.Time`.


```go
col := NewCollection()
col.CreateColumn("timestamp", ForRecord(func() *time.Time {
	return new(time.Time)
}, nil))

// Insert the time, it implements binary marshaler
idx, _ := col.Insert(func(r Row) error {
	now := time.Unix(1667745766, 0)
	r.SetRecord("timestamp", &now)
	return nil
})

// We should be able to read back the time
col.QueryAt(idx, func(r Row) error {
	ts, ok := r.Record("timestamp")
	assert.True(t, ok)
	assert.Equal(t, "November", ts.(*time.Time).UTC().Month().String())
	return nil
})
```