### PR TITLE
Fixed numeric merging options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.18"]
+        go: ["1.19"]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v3

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Now that we have a record implementation, we can create a column for this struct
 ```go
 players.CreateColumn("location", ForRecord(func() *Location {
 	return new(Location)
-}, nil)) // no merging
+}))
 ```
 
 In order to manipulate the record, we can use the appropriate `Record()`, `SetRecord()` methods of the `Row`, similarly to other column types.

--- a/codegen/numbers.tpl
+++ b/codegen/numbers.tpl
@@ -29,7 +29,7 @@ func make{{.Name}}s(opts ...func(*option[{{.Type}}])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -193,7 +193,7 @@ func BenchmarkRecord(b *testing.B) {
 		col := NewCollection()
 		col.CreateColumn("ts", ForRecord(func() *time.Time {
 			return new(time.Time)
-		}, nil))
+		}))
 
 		for i := 0; i < amount; i++ {
 			col.Insert(func(r Row) error {
@@ -247,7 +247,6 @@ func BenchmarkRecord(b *testing.B) {
 			})
 		}
 	})
-
 }
 
 func TestCollection(t *testing.T) {
@@ -802,7 +801,7 @@ func newEmpty(capacity int) *Collection {
 	out.CreateColumn("guild", ForEnum())
 	out.CreateColumn("location", ForRecord(func() *fixtures.Location {
 		return new(fixtures.Location)
-	}, nil))
+	}))
 
 	// index on humans
 	out.CreateIndex("human", "race", func(r Reader) bool {

--- a/column.go
+++ b/column.go
@@ -116,7 +116,7 @@ func ForKind(kind reflect.Kind) (Column, error) {
 
 // --------------------------- Generic Options ----------------------------
 
-// optInt represents options for variouos columns.
+// option represents options for variouos columns.
 type option[T any] struct {
 	Merge func(value, delta T) T
 }

--- a/column_numbers.go
+++ b/column_numbers.go
@@ -29,7 +29,7 @@ func makeInts(opts ...func(*option[int])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -78,7 +78,7 @@ func makeInt16s(opts ...func(*option[int16])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -127,7 +127,7 @@ func makeInt32s(opts ...func(*option[int32])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -176,7 +176,7 @@ func makeInt64s(opts ...func(*option[int64])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -225,7 +225,7 @@ func makeUints(opts ...func(*option[uint])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -274,7 +274,7 @@ func makeUint16s(opts ...func(*option[uint16])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -323,7 +323,7 @@ func makeUint32s(opts ...func(*option[uint32])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -372,7 +372,7 @@ func makeUint64s(opts ...func(*option[uint64])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -421,7 +421,7 @@ func makeFloat32s(opts ...func(*option[float32])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 
@@ -470,7 +470,7 @@ func makeFloat64s(opts ...func(*option[float64])) Column {
 					fill.Remove(offset)
 				}
 			}
-		},
+		}, opts,
 	)
 }
 

--- a/column_numeric.go
+++ b/column_numeric.go
@@ -37,7 +37,7 @@ type numericColumn[T simd.Number] struct {
 func makeNumeric[T simd.Number](
 	write func(*commit.Buffer, uint32, T),
 	apply func(*commit.Reader, bitmap.Bitmap, []T, option[T]),
-	opts ...func(*option[T]),
+	opts []func(*option[T]),
 ) *numericColumn[T] {
 	return &numericColumn[T]{
 		chunks: make(chunks[T], 0, 4),

--- a/commit/buffer_test.go
+++ b/commit/buffer_test.go
@@ -306,3 +306,17 @@ func TestBufferReadFromFailures(t *testing.T) {
 		assert.Error(t, err)
 	}
 }
+
+func FuzzBufferString(f *testing.F) {
+	f.Add(uint32(1), "test")
+
+	f.Fuzz(func(t *testing.T, i uint32, v string) {
+		buf := NewBuffer(0)
+		buf.PutString(Put, i, v)
+
+		r := NewReader()
+		r.Seek(buf)
+		assert.True(t, r.Next())
+		assert.Equal(t, v, r.String())
+	})
+}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -24,7 +24,7 @@ func main() {
 	players.CreateColumn("guild", column.ForEnum())
 	players.CreateColumn("location", column.ForRecord(func() *Location {
 		return new(Location)
-	}, nil))
+	}))
 
 	// index on humans
 	players.CreateIndex("human", "race", func(r column.Reader) bool {


### PR DESCRIPTION
This PR fixes merging options on numerical columns, the argument was not passed properly. Also added a few tests and removed mandatory merge function on record column, to make the API more consistent.