### PR TITLE
SortedIndex baseline implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           go mod download
       - name: Run Unit Tests
         run: |
-          go test -timeout 1200s -race -covermode atomic -coverprofile=profile.cov ./...
+          go test -race -covermode atomic -coverprofile=profile.cov ./...
       - name: Upload Coverage
         uses: shogo82148/actions-goveralls@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           go mod download
       - name: Run Unit Tests
         run: |
-          go test -race -covermode atomic -coverprofile=profile.cov ./...
+          go test -timeout 1200s -race -covermode atomic -coverprofile=profile.cov ./...
       - name: Upload Coverage
         uses: shogo82148/actions-goveralls@v1
         with:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ players.Query(func(txn *column.Txn) error {
 	name    := txn.String("name")
 	balance := txn.Float64("balance")
 
-	txn.With("rogue").SortedRange("richest", func (i uint32) {
+	txn.With("rogue").Ascend("richest", func (i uint32) {
 		// save or do something with sorted record
 		curName, _ := name.Get()
 		balance.Set(newBalance(curName))

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Along with bitmap indexing, collections support consistently sorted indexes. The
 In the example below, we create a SortedIndex object and use it to sort filtered records in a transaction.
 
 ```go
-// Create the index "sortedNames" in advance
-out.CreateIndex("richest", "balance")
+// Create the sorted index "sortedNames" in advance
+out.CreateSortIndex("richest", "balance")
 
 // This filters the transaction with the `rouge` index before
 // ranging through the remaining balances in ascending order

--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ players.Query(func(txn *column.Txn) error {
 })
 ```
 
+## Sorted Indexes
+
+Along with bitmap indexing, collections support consistently sorted indexes. These indexes are transient, and must be recreated when a collection is loading a snapshot. 
+
+In the example below, we create a SortedIndex object and use it to sort filtered records in a transaction.
+
+```go
+// Create the index "sortedNames" in advance
+out.CreateIndex("richest", "balance")
+
+// This filters the transaction with the `rouge` index before
+// ranging through the remaining balances in ascending order
+players.Query(func(txn *column.Txn) error {
+	name    := txn.String("name")
+	balance := txn.Float64("balance")
+
+	txn.With("rogue").SortedRange("richest", func (i uint32) {
+		// save or do something with sorted record
+		curName, _ := name.Get()
+		balance.Set(newBalance(curName))
+	})
+	return nil
+})
+```
+
 ## Updating Values
 
 In order to update certain items in the collection, you can simply call `Range()` method and use column accessor's `Set()` or `Add()` methods to update a value of a certain column atomically. The updates won't be instantly reflected given that our store supports transactions. Only when transaction is commited, then the update will be applied to the collection, allowing for isolation and rollbacks.

--- a/collection.go
+++ b/collection.go
@@ -286,6 +286,12 @@ func (c *Collection) CreateSortIndex(indexName, columnName string) error {
 		return fmt.Errorf("column: unable to create index, column '%v' does not exist", columnName)
 	}
 
+	// Check to make sure index does not already exist
+	_, ok = c.cols.Load(indexName)
+	if ok {
+		return fmt.Errorf("column: unable to create index, index '%v' already exist", indexName)
+	}
+
 	// Create and add the index column,
 	index := newSortIndex(indexName, columnName)
 	c.lock.Lock()
@@ -464,6 +470,18 @@ func (c *columns) LoadWithIndex(columnName string) ([]*column, bool) {
 	for _, v := range cols {
 		if v.name == columnName {
 			return v.cols, true
+		}
+	}
+	return nil, false
+}
+
+// LoadIndex loads an index column by its name.
+func (c *columns) LoadIndex(indexName string) (*column, bool) {
+	cols := c.cols.Load().([]columnEntry)
+	for _, v := range cols {
+		if v.name == indexName {
+			col := v.cols[0]
+			return col, col != nil
 		}
 	}
 	return nil, false

--- a/collection.go
+++ b/collection.go
@@ -475,18 +475,6 @@ func (c *columns) LoadWithIndex(columnName string) ([]*column, bool) {
 	return nil, false
 }
 
-// LoadIndex loads an index column by its name.
-func (c *columns) LoadIndex(indexName string) (*column, bool) {
-	cols := c.cols.Load().([]columnEntry)
-	for _, v := range cols {
-		if v.name == indexName {
-			col := v.cols[0]
-			return col, col != nil
-		}
-	}
-	return nil, false
-}
-
 // Store stores a column into the registry.
 func (c *columns) Store(columnName string, main *column, index ...*column) {
 

--- a/collection.go
+++ b/collection.go
@@ -275,6 +275,40 @@ func (c *Collection) CreateIndex(indexName, columnName string, fn func(r Reader)
 	return nil
 }
 
+func (c *Collection) CreateSortIndex(indexName, columnName string) error {
+	if columnName == "" || indexName == "" {
+		return fmt.Errorf("column: create index must specify name & column")
+	}
+
+	// Prior to creating an index, we should have a column
+	column, ok := c.cols.Load(columnName)
+	if !ok {
+		return fmt.Errorf("column: unable to create index, column '%v' does not exist", columnName)
+	}
+
+	// Create and add the index column,
+	index := newSortIndex(indexName, columnName)
+	c.lock.Lock()
+	// index.Grow(uint32(c.opts.Capacity))
+	c.cols.Store(indexName, index)
+	c.cols.Store(columnName, column, index)
+	c.lock.Unlock()
+
+	// Iterate over all of the values of the target column, chunk by chunk and fill
+	// the index accordingly.
+	chunks := c.chunks()
+	buffer := commit.NewBuffer(c.Count())
+	reader := commit.NewReader()
+	for chunk := commit.Chunk(0); int(chunk) < chunks; chunk++ {
+		if column.Snapshot(chunk, buffer) {
+			reader.Seek(buffer)
+			index.Apply(chunk, reader)
+		}
+	}
+
+	return nil
+}
+
 // DropIndex removes the index column with the specified name. If the index with this
 // name does not exist, this operation is a no-op.
 func (c *Collection) DropIndex(indexName string) error {

--- a/column_index.go
+++ b/column_index.go
@@ -206,18 +206,6 @@ func (c *columnSortIndex) Apply(chunk commit.Chunk, r *commit.Reader) {
 	for r.Next() {
 		switch r.Type {
 		case commit.Put:
-			/*delItem := SortIndexItem{"", 0}
-			c.btree.Scan(func (item SortIndexItem) bool {
-				if item.Value == r.Index() {
-					delItem.Key = item.Key
-					delItem.Value = item.Value
-					return false
-				}
-				return true
-			})
-			if delItem.Key != "" {
-				c.btree.Delete(delItem)
-			}*/
 			if delKey, exists := c.backMap[r.Index()]; exists {
 				c.btree.Delete(SortIndexItem{
 					Key: delKey,

--- a/column_index.go
+++ b/column_index.go
@@ -163,7 +163,6 @@ func (c *columnTrigger) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 
 // ----------------------- Sorted Index --------------------------
 
-// SortIndexItem represents an offset sorted in a generic BTree
 type SortIndexItem struct {
     Key    string
     Value  uint32

--- a/column_index.go
+++ b/column_index.go
@@ -246,5 +246,5 @@ func (c *columnSortIndex) Index(chunk commit.Chunk) bitmap.Bitmap {
 
 // Snapshot writes the entire column into the specified destination buffer
 func (c *columnSortIndex) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
-	// No op
+	// No-op
 }

--- a/commit/reader.go
+++ b/commit/reader.go
@@ -39,7 +39,7 @@ func (r *Reader) Rewind() {
 	r.Offset = r.start
 }
 
-// Use sets the buffer and resets the reader.
+// use sets the buffer and resets the reader.
 func (r *Reader) use(buffer []byte) {
 	r.buffer = buffer
 	r.headString = 0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kelindar/column
 go 1.19
 
 require (
+	github.com/imdario/mergo v0.3.13
 	github.com/kelindar/bitmap v1.4.1
 	github.com/kelindar/intmap v1.1.0
 	github.com/kelindar/iostream v1.3.0
@@ -12,6 +13,8 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/zeebo/xxh3 v1.0.2
 )
+
+require github.com/tidwall/btree v1.5.2 // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/zeebo/xxh3 v1.0.2
 )
 
-require github.com/tidwall/btree v1.5.2 // indirect
+require github.com/tidwall/btree v1.6.0 // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tidwall/btree v1.5.2 h1:5eA83Gfki799V3d3bJo9sWk+yL2LRoTEah3O/SA6/8w=
+github.com/tidwall/btree v1.5.2/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/kelindar/async v1.0.0 h1:oJiFAt3fVB/b5zVZKPBU+pP9lR3JVyeox9pYlpdnIK8=
 github.com/kelindar/async v1.0.0/go.mod h1:bJRlwaRiqdHi+4dpVDNHdwgyRyk6TxpA21fByLf7hIY=
 github.com/kelindar/bitmap v1.4.1 h1:Ih0BWMYXkkZxPMU536DsQKRhdvqFl7tuNjImfLJWC6E=
@@ -33,6 +34,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/btree v1.5.2 h1:5eA83Gfki799V3d3bJo9sWk+yL2LRoTEah3O/SA6/8w=
 github.com/tidwall/btree v1.5.2/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
+github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
+github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
@@ -45,5 +48,6 @@ golang.org/x/time v0.2.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/txn.go
+++ b/txn.go
@@ -401,12 +401,14 @@ func (txn *Txn) SortedRange(sortIndexName string, fn func(idx uint32)) error {
 	// TODO - better solution for linear txn index check
 	sortIndexCol, _ := sortIndex.Column.(*columnSortIndex)
 	sortIndexCol.btree.Scan(func (item SortIndexItem) bool {
+		/*
 		if txn.index.Contains(item.Value) {
 			fn(item.Value)
 		}
+		*/
 		// For each btree key, check if the offset is still in
 		// the txn's index & return if true
-		/*
+		
 		txn.rangeRead(func (chunk commit.Chunk, index bitmap.Bitmap) {
 			offset := chunk.Min()
 			index.Range(func(x uint32) {
@@ -415,7 +417,7 @@ func (txn *Txn) SortedRange(sortIndexName string, fn func(idx uint32)) error {
 					fn(item.Value)
 				}
 			})
-		})*/
+		})
 		return true
 	})
 	return nil

--- a/txn.go
+++ b/txn.go
@@ -401,8 +401,12 @@ func (txn *Txn) SortedRange(sortIndexName string, fn func(idx uint32)) error {
 	// TODO - better solution for linear txn index check
 	sortIndexCol, _ := sortIndex.Column.(*columnSortIndex)
 	sortIndexCol.btree.Scan(func (item SortIndexItem) bool {
+		if txn.index.Contains(item.Value) {
+			fn(item.Value)
+		}
 		// For each btree key, check if the offset is still in
 		// the txn's index & return if true
+		/*
 		txn.rangeRead(func (chunk commit.Chunk, index bitmap.Bitmap) {
 			offset := chunk.Min()
 			index.Range(func(x uint32) {
@@ -411,7 +415,7 @@ func (txn *Txn) SortedRange(sortIndexName string, fn func(idx uint32)) error {
 					fn(item.Value)
 				}
 			})
-		})
+		})*/
 		return true
 	})
 	return nil

--- a/txn.go
+++ b/txn.go
@@ -388,9 +388,9 @@ func (txn *Txn) Range(fn func(idx uint32)) error {
 	return nil
 }
 
-// SortedRange ascends through a given SortedIndex and returns each offset
+// Ascend through a given SortedIndex and returns each offset
 // remaining in the transaction's index
-func (txn *Txn) SortedRange(sortIndexName string, fn func(idx uint32)) error {
+func (txn *Txn) Ascend(sortIndexName string, fn func(idx uint32)) error {
 	txn.initialize()
 
 	sortIndex, ok := txn.owner.cols.Load(sortIndexName)

--- a/txn_test.go
+++ b/txn_test.go
@@ -301,7 +301,7 @@ func TestSortIndex(t *testing.T) {
 
 	// Range
 	assert.Error(t, c.Query(func (txn *Txn) error {
-		return txn.SortedRange("nonexistent", func (i uint32) {
+		return txn.Ascend("nonexistent", func (i uint32) {
 			return
 		})
 	}))
@@ -310,7 +310,7 @@ func TestSortIndex(t *testing.T) {
 	var resN int = 0
 	c.Query(func (txn *Txn) error {
 		col1 := txn.String("col1")
-		return txn.SortedRange("sortedCol1", func (i uint32) {
+		return txn.Ascend("sortedCol1", func (i uint32) {
 			name, _ := col1.Get()
 			res[resN] = name
 			resN++
@@ -338,7 +338,7 @@ func TestSortIndexLoad(t *testing.T) {
 	players.Query(func (txn *Txn) error {
 		txn = txn.With("human", "mage")
 		name := txn.String("name")
-		txn.SortedRange("sorted_names", func (i uint32) {
+		txn.Ascend("sorted_names", func (i uint32) {
 			n, _ := name.Get()
 			if res, exists := checks[checkN]; exists {
 				assert.Equal(t, res, n)
@@ -372,7 +372,7 @@ func TestSortIndexChunks(t *testing.T) {
 
 	players.Query(func (txn *Txn) error {
 		name := txn.String("name")
-		txn.SortedRange("sorted_names", func (i uint32) {
+		txn.Ascend("sorted_names", func (i uint32) {
 			n, _ := name.Get()
 			if i % 400 == 0 {
 				nInt, _ := strconv.Atoi(n)
@@ -382,7 +382,6 @@ func TestSortIndexChunks(t *testing.T) {
 		return nil
 	})
 }
-
 
 func TestDeleteAll(t *testing.T) {
 	players := loadPlayers(500)

--- a/txn_test.go
+++ b/txn_test.go
@@ -390,7 +390,6 @@ func TestSortIndexChunks(t *testing.T) {
 	order.Add(1)
 
 	// Do the same test as before at the same time as other updates
-	// go func(order *sync.WaitGroup) {
 	go func() {
 		players.Query(func (txn *Txn) error {
 			name := txn.String("name")
@@ -407,7 +406,6 @@ func TestSortIndexChunks(t *testing.T) {
 		wg.Done()
 	}()
 	
-	//go func(order *sync.WaitGroup) {
 	go func() {
 		order.Wait() // Wait for scan to begin
 		idx1 := xxrand.Uint32n(uint32(N / 400)) * 400 // hit checked idxs only

--- a/txn_test.go
+++ b/txn_test.go
@@ -270,6 +270,14 @@ func TestSortIndex(t *testing.T) {
 	assert.Error(t, c.CreateSortIndex("no_col", "nonexistent"))
 	assert.Error(t, c.CreateSortIndex("sortedCol1", "col1"))
 
+	indexCol, _ := c.cols.Load("sortedCol1")
+	assert.False(t, indexCol.Column.(*columnSortIndex).Contains(0))
+	assert.Nil(t, indexCol.Column.(*columnSortIndex).Index(0))
+	assert.NotPanics(t, func() {
+		indexCol.Column.(*columnSortIndex).Grow(100)
+		indexCol.Column.(*columnSortIndex).Snapshot(0, nil)
+	})
+
 	// Inserts
 	c.Insert(func (r Row) error {
 		r.SetString("col1", "bob")
@@ -293,7 +301,6 @@ func TestSortIndex(t *testing.T) {
 		r.SetString("col1", "rob")
 		return nil
 	}))
-	indexCol, _ := c.cols.Load("sortedCol1")
 	assert.Equal(t, 4, indexCol.Column.(*columnSortIndex).btree.Len())
 	
 	// Delete

--- a/txn_test.go
+++ b/txn_test.go
@@ -271,6 +271,7 @@ func TestSortIndex(t *testing.T) {
 	assert.Error(t, c.CreateSortIndex("sortedCol1", "col1"))
 
 	indexCol, _ := c.cols.Load("sortedCol1")
+	assert.Equal(t, "col1", indexCol.Column.(*columnSortIndex).Column())
 	assert.False(t, indexCol.Column.(*columnSortIndex).Contains(0))
 	assert.Nil(t, indexCol.Column.(*columnSortIndex).Index(0))
 	assert.NotPanics(t, func() {

--- a/txn_test.go
+++ b/txn_test.go
@@ -278,15 +278,27 @@ func TestSortIndex(t *testing.T) {
 		return nil
 	})
 	c.Insert(func (r Row) error {
+		r.SetString("col1", "dan")
+		return nil
+	})
+	c.Insert(func (r Row) error {
 		r.SetString("col1", "alice")
 		return nil
 	})
+	assert.NoError(t, c.QueryAt(3, func(r Row) error {
+		r.SetString("col1", "rob")
+		return nil
+	}))
+	assert.Equal(t, true, c.DeleteAt(1))
 
 	assert.Error(t, c.Query(func (txn *Txn) error {
 		return txn.SortedRange("nonexistent", func (i uint32) {
 			return
 		})
 	}))
+
+	indexCol, _ := c.cols.Load("sortedCol1")
+	assert.Equal(t, 3, indexCol.Column.(*columnSortIndex).btree.Len())
 
 	var res [3]string
 	var resN int = 0
@@ -299,9 +311,9 @@ func TestSortIndex(t *testing.T) {
 		})
 	})
 
-	assert.Equal(t, "alice", res[0])
-	assert.Equal(t, "bob", res[1])
-	assert.Equal(t, "carter", res[2])
+	assert.Equal(t, "bob", res[0])
+	assert.Equal(t, "dan", res[1])
+	assert.Equal(t, "rob", res[2])
 }
 
 func TestSortIndexLoad(t *testing.T) {

--- a/txn_test.go
+++ b/txn_test.go
@@ -274,6 +274,9 @@ func TestSortIndex(t *testing.T) {
 	assert.Equal(t, "col1", indexCol.Column.(*columnSortIndex).Column())
 	assert.False(t, indexCol.Column.(*columnSortIndex).Contains(0))
 	assert.Nil(t, indexCol.Column.(*columnSortIndex).Index(0))
+	v, ok := indexCol.Column.(*columnSortIndex).Value(0)
+	assert.Nil(t, v)
+	assert.False(t, ok)
 	assert.NotPanics(t, func() {
 		indexCol.Column.(*columnSortIndex).Grow(100)
 		indexCol.Column.(*columnSortIndex).Snapshot(0, nil)


### PR DESCRIPTION
This PR introduces a new Sorted Index that keeps an actively sorted b-tree (github.com/tidwall/btree) for a column of the user's choosing (currently limited to string-type only). The index holds one b-tree that is not copied between transactions (mutexed).

Future work would consider other type columns being sorted (currently only string columns), PK sorting, and custom `Less()` functionality for users.