### PR TITLE
CreateTrigger and DropTrigger

### DIFF
--- a/column_index.go
+++ b/column_index.go
@@ -12,6 +12,8 @@ import (
 
 // Reader represents a reader cursor for a specific row/column combination.
 type Reader interface {
+	IsUpsert() bool
+	IsDelete() bool
 	Index() uint32
 	String() string
 	Bytes() []byte
@@ -25,12 +27,12 @@ type Reader interface {
 // this so that we can feed it to the index transparently.
 var _ Reader = new(commit.Reader)
 
-// --------------------------- Index ----------------------------
-
 // computed represents a computed column
 type computed interface {
 	Column() string
 }
+
+// --------------------------- Index ----------------------------
 
 // columnIndex represents the index implementation
 type columnIndex struct {
@@ -99,4 +101,59 @@ func (c *columnIndex) Index(chunk commit.Chunk) bitmap.Bitmap {
 // Snapshot writes the entire column into the specified destination buffer
 func (c *columnIndex) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
 	dst.PutBitmap(commit.PutTrue, chunk, c.fill)
+}
+
+// --------------------------- Trigger ----------------------------
+
+// columnTrigger represents the trigger implementation
+type columnTrigger struct {
+	name string       // The name of the target column
+	clbk func(Reader) // The trigger callback
+}
+
+// newTrigger creates a new trigger column.
+func newTrigger(indexName, columnName string, callback func(r Reader)) *column {
+	return columnFor(indexName, &columnTrigger{
+		name: columnName,
+		clbk: callback,
+	})
+}
+
+// Grow grows the size of the column until we have enough to store
+func (c *columnTrigger) Grow(idx uint32) {
+	// Noop
+}
+
+// Column returns the target name of the column on which this index should apply.
+func (c *columnTrigger) Column() string {
+	return c.name
+}
+
+// Apply applies a set of operations to the column.
+func (c *columnTrigger) Apply(chunk commit.Chunk, r *commit.Reader) {
+	for r.Next() {
+		if r.Type == commit.Put || r.Type == commit.Delete {
+			c.clbk(r)
+		}
+	}
+}
+
+// Value retrieves a value at a specified index.
+func (c *columnTrigger) Value(idx uint32) (v any, ok bool) {
+	return nil, false
+}
+
+// Contains checks whether the column has a value at a specified index.
+func (c *columnTrigger) Contains(idx uint32) bool {
+	return false
+}
+
+// Index returns the fill list for the column
+func (c *columnTrigger) Index(chunk commit.Chunk) bitmap.Bitmap {
+	return nil
+}
+
+// Snapshot writes the entire column into the specified destination buffer
+func (c *columnTrigger) Snapshot(chunk commit.Chunk, dst *commit.Buffer) {
+	// Noop
 }

--- a/commit/reader.go
+++ b/commit/reader.go
@@ -156,6 +156,16 @@ func (r *Reader) Bool() bool {
 	return r.Type == PutTrue
 }
 
+// IsUpsert returns true if the current operation is an insert or update
+func (r *Reader) IsUpsert() bool {
+	return r.Type == Put
+}
+
+// IsDelete returns true if the current operation is a deletion
+func (r *Reader) IsDelete() bool {
+	return r.Type == Delete
+}
+
 // --------------------------- Value Swap ----------------------------
 
 // SwapInt16 swaps a uint16 value with a new one.

--- a/commit/reader_test.go
+++ b/commit/reader_test.go
@@ -327,3 +327,16 @@ func TestMergeStrings(t *testing.T) {
 		"(put) 36",
 	}, scanned)
 }
+
+func TestReaderIsUpsert(t *testing.T) {
+	buf := NewBuffer(0)
+	buf.PutFloat32(Put, 0, 10)
+	buf.PutFloat32(Delete, 0, 0)
+
+	r := NewReader()
+	r.Seek(buf)
+	assert.True(t, r.Next())
+	assert.True(t, r.IsUpsert())
+	assert.True(t, r.Next())
+	assert.True(t, r.IsDelete())
+}


### PR DESCRIPTION
This PR adds `trigger` functionality for the cases where built-in capabilities aren't sufficient. Triggers allow you to add a callback function that will get called whether a value is `inserted`, `updated` or `deleted`. It functions similarly to the bitmap index.


```go
players.CreateTrigger("on_balance", "balance", func(r Reader) {
	switch {
	case r.IsDelete():
		updates = append(updates, fmt.Sprintf("delete %d", r.Index()))
	case r.IsUpsert():
		updates = append(updates, fmt.Sprintf("upsert %d=%v", r.Index(), r.Float()))
	}
})

// Perform a few deletions and insertions
for i := 0; i < 3; i++ {
	players.DeleteAt(uint32(i))
	players.Insert(func(r Row) error {
		r.SetFloat64("balance", 50.0)
		return nil
	})
}

// Must keep track of all operations
assert.Len(t, updates, 6)
assert.Equal(t, []string{
	"delete 0", 
	"upsert 500=50", 
	"delete 1", 
	"upsert 501=50", 
	"delete 2",
	"upsert 502=50",
}, updates)
```