### PR TITLE
Fix withValue on record column type

### DIFF
--- a/column_record.go
+++ b/column_record.go
@@ -71,6 +71,17 @@ func ForRecord[T recordType](new func() T, opts ...func(*option[T])) Column {
 	}
 }
 
+// Value returns the value at the given index
+// TODO: should probably get rid of this and use an `rdRecord` instead
+func (c *columnRecord) Value(idx uint32) (any, bool) {
+	if v, ok := c.columnString.Value(idx); ok {
+		out := c.pool.New().(encoding.BinaryUnmarshaler)
+		err := out.UnmarshalBinary(s2b(v.(string)))
+		return out, err == nil
+	}
+	return nil, false
+}
+
 // --------------------------- Writer ----------------------------
 
 // rwRecord represents read-write accessor for primary keys.

--- a/column_record.go
+++ b/column_record.go
@@ -73,13 +73,12 @@ func ForRecord[T recordType](new func() T, opts ...func(*option[T])) Column {
 
 // Value returns the value at the given index
 // TODO: should probably get rid of this and use an `rdRecord` instead
-func (c *columnRecord) Value(idx uint32) (any, bool) {
+func (c *columnRecord) Value(idx uint32) (out any, has bool) {
 	if v, ok := c.columnString.Value(idx); ok {
-		out := c.pool.New().(encoding.BinaryUnmarshaler)
-		err := out.UnmarshalBinary(s2b(v.(string)))
-		return out, err == nil
+		out = c.pool.New()
+		has = out.(encoding.BinaryUnmarshaler).UnmarshalBinary(s2b(v.(string))) == nil
 	}
-	return nil, false
+	return
 }
 
 // --------------------------- Writer ----------------------------

--- a/column_test.go
+++ b/column_test.go
@@ -734,6 +734,24 @@ func TestNumberMerge(t *testing.T) {
 	})
 }
 
+func TestIssue87(t *testing.T) {
+	table := NewCollection()
+	table.CreateColumn("birthdate", ForRecord(func() *time.Time { return new(time.Time) }))
+
+	srcDate := time.Date(1999, 3, 2, 12, 0, 0, 0, time.Local)
+	table.Insert(func(r Row) error {
+		r.SetRecord("birthdate", srcDate)
+		return nil
+	})
+
+	table.Query(func(txn *Txn) error {
+		assert.Equal(t, txn.WithValue("birthdate", func(v any) bool {
+			return v.(*time.Time).Equal(srcDate)
+		}).Count(), 1)
+		return nil
+	})
+}
+
 // Tests the case where a column is created after inserting a large enough amount of data
 func TestIssue89(t *testing.T) {
 	coll := NewCollection()


### PR DESCRIPTION
This PR fixes issue #87 where `WithValue()` wasn't unmarshaling the record.