### PR TITLE
Using `r.String()` instead of `string(r.Bytes())` to avoid allocation

### DIFF
--- a/column_strings.go
+++ b/column_strings.go
@@ -179,7 +179,7 @@ func (c *columnString) Apply(chunk commit.Chunk, r *commit.Reader) {
 		switch r.Type {
 		case commit.Put:
 			fill[offset>>6] |= 1 << (offset & 0x3f)
-			data[offset] = string(r.Bytes())
+			data[offset] = r.String()
 		case commit.Merge:
 			fill[offset>>6] |= 1 << (offset & 0x3f)
 			data[offset] = r.SwapString(c.Merge(data[offset], r.String()))
@@ -285,7 +285,7 @@ func (c *columnKey) Apply(chunk commit.Chunk, r *commit.Reader) {
 		offset := r.Offset - int32(from)
 		switch r.Type {
 		case commit.Put:
-			value := string(r.Bytes())
+			value := r.String()
 
 			fill[offset>>6] |= 1 << (offset & 0x3f)
 			data[offset] = value


### PR DESCRIPTION
I was doing some profiling on a project utilizing column recently and saw that there was quite a bit of time/memory spent on the conversion from `[]byte` to `string` in these two areas.

At first glance it looks like we should just be able to replace the conversion with the "direct" unsafe pointer conversion, but I'm unsure if you had any particular reason for keeping the allocation. If there is a particular reason then feel free to close this PR and I can open a new one to leave comments in these two places outlining why the allocation is necessary.