### PR TITLE
Return cursor index

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -89,6 +89,11 @@ type Txn struct {
 	reader  *commit.Reader   // The commit reader to re-use
 }
 
+// Index returns the current index
+func (txn *Txn) Index() uint32 {
+	return txn.cursor
+}
+
 // Reset resets the transaction state so it can be used again.
 func (txn *Txn) reset() {
 	for i := range txn.updates {

--- a/txn_row.go
+++ b/txn_row.go
@@ -15,6 +15,11 @@ type Row struct {
 	txn *Txn
 }
 
+// Index returns the index of the row
+func (r Row) Index() uint32 {
+	return r.txn.Index()
+}
+
 // --------------------------- Numbers ----------------------------
 
 // Int loads a int value at a particular column


### PR DESCRIPTION
This PR adds `Index()` function to the transaction, returning the current cursor index. 